### PR TITLE
Create abilities tab

### DIFF
--- a/src/components/AbilityScoreTab.svelte
+++ b/src/components/AbilityScoreTab.svelte
@@ -108,6 +108,22 @@
         }
       }}>Roll</button
     >
+    <button
+      type="button"
+      on:click={() => {
+        if (data.abilities.mode !== "manual") {
+          data.abilities.mode = "manual";
+          data.abilities.data = {
+            str: 10,
+            con: 10,
+            dex: 10,
+            int: 10,
+            wis: 10,
+            cha: 10,
+          };
+        }
+      }}>Manual</button
+    >
   </div>
 
   {#if data.abilities.mode === "pointbuy"}
@@ -178,6 +194,14 @@
               disabled={data.abilities.pointBuyBudget - costOfIncrease(ability) < 0 || value === 15}
               on:click={() => raiseAbilityScore(ability)}><i class="fas fa-plus" /></button
             >
+          {:else if data.abilities.mode === "manual"}
+            <input
+              type="number"
+              value={data.abilities.data[ability]}
+              on:change={(event) => {
+                data.abilities.data[ability] = parseInt(event.target.value);
+              }}
+            />
           {/if}
         </div>
         {#if value && value >= 10}
@@ -200,6 +224,11 @@
 </div>
 
 <style>
+  input[type="number"] {
+    width: 36px;
+    font-size: 24px;
+  }
+
   .ability-scores-tab {
     margin: 0 0.5rem;
   }

--- a/src/components/AbilityScoreTab.svelte
+++ b/src/components/AbilityScoreTab.svelte
@@ -5,7 +5,6 @@
 
   export let data;
 
-  let standardScores = [8, 10, 12, 13, 14, 15];
   let pointBuyCosts = {
     8: 0,
     9: 1,
@@ -88,8 +87,6 @@
       on:click={() => {
         if (data.abilities.mode !== "standard") {
           data.abilities.mode = "standard";
-          data.abilities.rolledScores = standardScores;
-          data.abilities.availableScores = [...data.abilities.rolledScores];
           data.abilities.data.abilities = {
             str: undefined,
             con: undefined,
@@ -98,6 +95,8 @@
             wis: undefined,
             cha: undefined,
           };
+          data.abilities.rolledScores = [15, 14, 13, 12, 10, 8];
+          data.abilities.availableScores = [...data.abilities.rolledScores];
         }
       }}>Standard</button
     >

--- a/src/components/AbilityScoreTab.svelte
+++ b/src/components/AbilityScoreTab.svelte
@@ -32,23 +32,25 @@
 
   function reduceAbilityScore(ability) {
     data.abilities.pointBuyBudget += costOfDecrease(ability);
-    data.abilities.data[ability] -= 1;
+    data.abilities.data.abilities[ability] -= 1;
   }
 
   function raiseAbilityScore(ability) {
     data.abilities.pointBuyBudget -= costOfIncrease(ability);
-    data.abilities.data[ability] += 1;
+    data.abilities.data.abilities[ability] += 1;
   }
 
   function costOfIncrease(ability) {
     return (
-      pointBuyCosts[data.abilities.data[ability] + 1] - pointBuyCosts[data.abilities.data[ability]]
+      pointBuyCosts[data.abilities.data.abilities[ability] + 1] -
+      pointBuyCosts[data.abilities.data.abilities[ability]]
     );
   }
 
   function costOfDecrease(ability) {
     return (
-      pointBuyCosts[data.abilities.data[ability]] - pointBuyCosts[data.abilities.data[ability] - 1]
+      pointBuyCosts[data.abilities.data.abilities[ability]] -
+      pointBuyCosts[data.abilities.data.abilities[ability] - 1]
     );
   }
 </script>
@@ -63,7 +65,7 @@
           data.abilities.mode = "standard";
           data.abilities.rolledScores = standardScores;
           data.abilities.availableScores = [...data.abilities.rolledScores];
-          data.abilities.data = {
+          data.abilities.data.abilities = {
             str: undefined,
             con: undefined,
             dex: undefined,
@@ -81,7 +83,7 @@
         if (data.abilities.mode !== "pointbuy") {
           data.abilities.mode = "pointbuy";
           data.abilities.pointBuyBudget = 27;
-          data.abilities.data = {
+          data.abilities.data.abilities = {
             str: 8,
             con: 8,
             dex: 8,
@@ -98,7 +100,7 @@
       on:click={() => {
         if (data.abilities.mode !== "roll") {
           data.abilities.mode = "roll";
-          data.abilities.data = {
+          data.abilities.data.abilities = {
             str: undefined,
             con: undefined,
             dex: undefined,
@@ -117,7 +119,7 @@
       on:click={() => {
         if (data.abilities.mode !== "manual") {
           data.abilities.mode = "manual";
-          data.abilities.data = {
+          data.abilities.data.abilities = {
             str: 10,
             con: 10,
             dex: 10,
@@ -134,7 +136,7 @@
     <div class="point-buy-budget"><b>Points Remaining:</b> {data.abilities.pointBuyBudget}/27</div>
   {/if}
   <div class="ability-score-row">
-    {#each Object.entries(data.abilities.data) as [ability, value]}
+    {#each Object.entries(data.abilities.data.abilities) as [ability, value]}
       <div
         class="ability-score"
         class:current={currentAbility === ability}
@@ -149,16 +151,16 @@
             <select
               on:change={(event) => {
                 event.preventDefault();
-                if (data.abilities.data[ability]) {
+                if (data.abilities.data.abilities[ability]) {
                   data.abilities.availableScores = [
                     ...data.abilities.availableScores,
-                    data.abilities.data[ability],
+                    data.abilities.data.abilities[ability],
                   ];
                 }
 
                 if (parseInt(event.target.value)) {
                   const value = parseInt(event.target.value);
-                  data.abilities.data[ability] = value;
+                  data.abilities.data.abilities[ability] = value;
 
                   data.abilities.availableScores.splice(
                     data.abilities.availableScores.findIndex((a) => a === value),
@@ -168,7 +170,7 @@
                   // Must reassign for svelte to update
                   data.abilities.availableScores = data.abilities.availableScores;
                 } else {
-                  data.abilities.data[ability] = undefined;
+                  data.abilities.data.abilities[ability] = undefined;
                 }
               }}
             >
@@ -176,8 +178,7 @@
               {#each data.abilities.rolledScores as score}
                 <option
                   disabled={!data.abilities.availableScores.includes(score)}
-                  selected={!data.abilities.data[ability] && data.abilities.data[ability] === score}
-                  >{score}</option
+                  selected={data.abilities.data.abilities[ability] === score}>{score}</option
                 >
               {/each}
             </select>
@@ -199,9 +200,9 @@
           {:else if data.abilities.mode === "manual"}
             <input
               type="number"
-              value={data.abilities.data[ability]}
+              value={data.abilities.data.abilities[ability]}
               on:change={(event) => {
-                data.abilities.data[ability] = parseInt(event.target.value);
+                data.abilities.data.abilities[ability] = parseInt(event.target.value);
               }}
             />
           {/if}

--- a/src/components/AbilityScoreTab.svelte
+++ b/src/components/AbilityScoreTab.svelte
@@ -1,0 +1,240 @@
+<script>
+  import AbilityAbbreviations from "data/abilityAbbreviations.js";
+
+  export let data;
+
+  let standardScores = [8, 10, 12, 13, 14, 15];
+  let pointBuyCosts = {
+    8: 0,
+    9: 1,
+    10: 2,
+    11: 3,
+    12: 4,
+    13: 5,
+    14: 7,
+    15: 9,
+  };
+  let abilityDescriptionMap;
+  let currentAbility;
+  let description;
+
+  $: abilityDescriptionMap = Object.fromEntries(
+    Object.entries(AbilityAbbreviations).map(([abbr, label]) => [
+      abbr,
+      fetch(`modules/herosmith/templates/ability-descriptions/${label.toLowerCase()}.html`).then(
+        (response) => response.text()
+      ),
+    ])
+  );
+
+  $: description = abilityDescriptionMap[currentAbility];
+
+  function reduceAbilityScore(ability) {
+    data.abilities.pointBuyBudget += costOfDecrease(ability);
+    data.abilities.data[ability] -= 1;
+  }
+
+  function raiseAbilityScore(ability) {
+    data.abilities.pointBuyBudget -= costOfIncrease(ability);
+    data.abilities.data[ability] += 1;
+  }
+
+  function costOfIncrease(ability) {
+    return (
+      pointBuyCosts[data.abilities.data[ability] + 1] - pointBuyCosts[data.abilities.data[ability]]
+    );
+  }
+
+  function costOfDecrease(ability) {
+    return (
+      pointBuyCosts[data.abilities.data[ability]] - pointBuyCosts[data.abilities.data[ability] - 1]
+    );
+  }
+</script>
+
+<div class="ability-scores-tab">
+  <div class="mode-select">
+    <button
+      type="button"
+      on:click={() => {
+        if (data.abilities.mode !== "standard") {
+          data.abilities.mode = "standard";
+          data.abilities.data = {
+            str: undefined,
+            con: undefined,
+            dex: undefined,
+            int: undefined,
+            wis: undefined,
+            cha: undefined,
+          };
+        }
+      }}>Standard</button
+    >
+    <button
+      type="button"
+      on:click={() => {
+        if (data.abilities.mode !== "pointbuy") {
+          data.abilities.mode = "pointbuy";
+          data.abilities.pointBuyBudget = 27;
+          data.abilities.data = {
+            str: 8,
+            con: 8,
+            dex: 8,
+            int: 8,
+            wis: 8,
+            cha: 8,
+          };
+        }
+      }}>Point Buy</button
+    >
+  </div>
+
+  {#if data.abilities.mode === "pointbuy"}
+    <div class="point-buy-budget"><b>Points Remaining:</b> {data.abilities.pointBuyBudget}/27</div>
+  {/if}
+  <div class="ability-score-row">
+    {#each Object.entries(data.abilities.data) as [ability, value]}
+      <div
+        class="ability-score"
+        class:current={currentAbility === ability}
+        on:pointerenter={() => {
+          currentAbility = ability;
+        }}
+      >
+        <div class="label">{AbilityAbbreviations[ability]}</div>
+        <div class="value-bar">
+          {#if data.abilities.mode === "standard"}
+            <!-- svelte-ignore a11y-no-onchange -->
+            <select
+              on:change={(event) => {
+                data.abilities.data[ability] = parseInt(event.target.value);
+              }}
+            >
+              <option>--</option>
+              {#each standardScores as score}
+                <option
+                  disabled={Object.values(data.abilities.data).includes(score)}
+                  selected={data.abilities.data[ability] === score}>{score}</option
+                >
+              {/each}
+            </select>
+          {:else if data.abilities.mode === "pointbuy"}
+            <button
+              type="button"
+              class="adjust-button"
+              disabled={value === 8}
+              on:click={() => reduceAbilityScore(ability)}><i class="fas fa-minus" /></button
+            >
+            <div class="value">{value}</div>
+
+            <button
+              type="button"
+              class="adjust-button"
+              disabled={data.abilities.pointBuyBudget - costOfIncrease(ability) < 0 || value === 15}
+              on:click={() => raiseAbilityScore(ability)}><i class="fas fa-plus" /></button
+            >
+          {/if}
+        </div>
+        {#if value && value >= 10}
+          <div class="modifier">{`+ ${Math.abs(Math.floor((value - 10) / 2))}`}</div>
+        {/if}
+        {#if value && value < 10}
+          <div class="modifier">{`- ${Math.abs(Math.floor((value - 10) / 2))}`}</div>
+        {/if}
+      </div>
+    {/each}
+  </div>
+
+  <div class="ability-description">
+    {#if description}
+      {#await description then html}
+        {@html html}
+      {/await}
+    {/if}
+  </div>
+</div>
+
+<style>
+  .ability-scores-tab {
+    margin: 0 0.5rem;
+  }
+  .ability-score {
+    font-family: "Modesto Condensed", "Palatino Linotype", serif;
+    text-align: center;
+    border: 2px groove #eeede0;
+    border-radius: 2px;
+    padding: 0.5rem 0;
+    margin: 0;
+  }
+
+  .ability-description {
+    margin-top: 0.5rem;
+  }
+
+  .current {
+    border-color: #782e22;
+  }
+
+  .ability-score-row {
+    display: grid;
+    grid-gap: 2px;
+    grid-template-columns: repeat(6, 1fr);
+  }
+
+  .label {
+    font-size: 24px;
+    font-weight: 600;
+  }
+
+  i {
+    margin: 0;
+  }
+
+  .mode-select {
+    display: flex;
+    margin-bottom: 1em;
+  }
+
+  .point-buy-budget {
+    text-align: center;
+    font-size: 20px;
+  }
+
+  .adjust-button {
+    max-width: 30px;
+    max-height: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  select {
+    font-family: "Modesto Condensed", "Palatino Linotype", serif;
+    font-size: 16px;
+    text-align-last: center;
+  }
+
+  button:hover {
+    cursor: pointer;
+  }
+
+  button:disabled {
+    opacity: 40%;
+  }
+
+  .value-bar {
+    display: flex;
+    justify-content: center;
+  }
+
+  .value {
+    font-size: 28px;
+    padding: 0 0.25rem;
+  }
+
+  .modifier {
+    display: flex;
+    justify-content: center;
+    font-size: 20px;
+  }
+</style>

--- a/src/components/AbilityScoreTab.svelte
+++ b/src/components/AbilityScoreTab.svelte
@@ -57,6 +57,7 @@
   <div class="mode-select">
     <button
       type="button"
+      class:selected={data.abilities.mode === "standard"}
       on:click={() => {
         if (data.abilities.mode !== "standard") {
           data.abilities.mode = "standard";
@@ -75,6 +76,7 @@
     >
     <button
       type="button"
+      class:selected={data.abilities.mode === "pointbuy"}
       on:click={() => {
         if (data.abilities.mode !== "pointbuy") {
           data.abilities.mode = "pointbuy";
@@ -92,6 +94,7 @@
     >
     <button
       type="button"
+      class:selected={data.abilities.mode === "roll"}
       on:click={() => {
         if (data.abilities.mode !== "roll") {
           data.abilities.mode = "roll";
@@ -110,6 +113,7 @@
     >
     <button
       type="button"
+      class:selected={data.abilities.mode === "manual"}
       on:click={() => {
         if (data.abilities.mode !== "manual") {
           data.abilities.mode = "manual";
@@ -310,5 +314,9 @@
     display: flex;
     justify-content: center;
     font-size: 20px;
+  }
+
+  .selected {
+    border-color: #782e22;
   }
 </style>

--- a/src/components/AbilityScoreTab.svelte
+++ b/src/components/AbilityScoreTab.svelte
@@ -1,6 +1,7 @@
 <script>
   import AbilityAbbreviations from "data/abilityAbbreviations.js";
   import rollStats from "utils/rollStats.js";
+  import { uniq } from "lodash";
 
   export let data;
 
@@ -52,6 +53,30 @@
       pointBuyCosts[data.abilities.data.abilities[ability]] -
       pointBuyCosts[data.abilities.data.abilities[ability] - 1]
     );
+  }
+
+  function availableOptions(ability) {
+    let optionsHtmlString = "<option>--</option>";
+    for (const score of uniq(data.abilities.rolledScores)) {
+      const pickedOccurrences = Object.values(data.abilities.data.abilities).filter(
+        (s) => s === score
+      ).length;
+      const availableOccurrences = data.abilities.availableScores.filter((s) => s === score).length;
+
+      for (let i = 0; i < pickedOccurrences; i++) {
+        if (data.abilities.data.abilities[ability] === score) {
+          optionsHtmlString += `<option disabled selected>${score}</option>`;
+        } else {
+          optionsHtmlString += `<option disabled>${score}</option>`;
+        }
+      }
+
+      for (let i = 0; i < availableOccurrences; i++) {
+        optionsHtmlString += `<option>${score}</option>`;
+      }
+    }
+
+    return optionsHtmlString;
   }
 </script>
 
@@ -174,13 +199,7 @@
                 }
               }}
             >
-              <option>--</option>
-              {#each data.abilities.rolledScores as score}
-                <option
-                  disabled={!data.abilities.availableScores.includes(score)}
-                  selected={data.abilities.data.abilities[ability] === score}>{score}</option
-                >
-              {/each}
+              {@html availableOptions(ability)}
             </select>
           {:else if data.abilities.mode === "pointbuy"}
             <button

--- a/src/components/AbilityScoreTab.svelte
+++ b/src/components/AbilityScoreTab.svelte
@@ -132,7 +132,7 @@
                   data.abilities.availableScores = [
                     ...data.abilities.availableScores,
                     data.abilities.data[ability],
-                  ];
+                  ].sort((a, b) => b - a);
                 }
 
                 if (parseInt(event.target.value)) {
@@ -158,7 +158,8 @@
               {#each data.abilities.availableScores as score}
                 <option
                   disabled={!data.abilities.availableScores.includes(score)}
-                  selected={data.abilities.data[ability] === score}>{score}</option
+                  selected={!data.abilities.data[ability] && data.abilities.data[ability] === score}
+                  >{score}</option
                 >
               {/each}
             </select>

--- a/src/components/AbilityScoreTab.svelte
+++ b/src/components/AbilityScoreTab.svelte
@@ -148,11 +148,12 @@
             <!-- svelte-ignore a11y-no-onchange -->
             <select
               on:change={(event) => {
+                event.preventDefault();
                 if (data.abilities.data[ability]) {
                   data.abilities.availableScores = [
                     ...data.abilities.availableScores,
                     data.abilities.data[ability],
-                  ].sort((a, b) => b - a);
+                  ];
                 }
 
                 if (parseInt(event.target.value)) {
@@ -171,11 +172,8 @@
                 }
               }}
             >
-              {#if data.abilities.data[ability]}
-                <option selected>{data.abilities.data[ability]}</option>
-              {/if}
               <option>--</option>
-              {#each data.abilities.availableScores as score}
+              {#each data.abilities.rolledScores as score}
                 <option
                   disabled={!data.abilities.availableScores.includes(score)}
                   selected={!data.abilities.data[ability] && data.abilities.data[ability] === score}

--- a/src/components/AbilityScoreTab.svelte
+++ b/src/components/AbilityScoreTab.svelte
@@ -151,8 +151,11 @@
                 }
               }}
             >
+              {#if data.abilities.data[ability]}
+                <option selected>{data.abilities.data[ability]}</option>
+              {/if}
               <option>--</option>
-              {#each data.abilities.rolledScores as score}
+              {#each data.abilities.availableScores as score}
                 <option
                   disabled={!data.abilities.availableScores.includes(score)}
                   selected={data.abilities.data[ability] === score}>{score}</option

--- a/src/components/CharacterCreation.svelte
+++ b/src/components/CharacterCreation.svelte
@@ -22,6 +22,8 @@
       },
       mode: "pointbuy",
       pointBuyBudget: 27,
+      rolledScores: [],
+      availableScores: [],
     },
     race: {
       uuid: "",
@@ -49,6 +51,8 @@
       decisionData: {},
     },
   };
+  $: console.log(data.abilities.rolledScores);
+  $: console.log(data.abilities.availableScores);
 
   let tabs = ["Races", "Class", "Abilities", "Background", "Review"];
   let currentTab = "Races";

--- a/src/components/CharacterCreation.svelte
+++ b/src/components/CharacterCreation.svelte
@@ -3,6 +3,7 @@
   import ClassTab from "components/ClassTab.svelte";
   import BackgroundTab from "components/BackgroundTab.svelte";
   import ReviewTab from "components/ReviewTab.svelte";
+  import AbilityScoreTab from "components/AbilityScoreTab.svelte";
   import { capitalize } from "utils/utils.js";
   import { mergeWith } from "lodash";
   import { mergeCustomizer } from "utils/utils.js";
@@ -10,6 +11,18 @@
   export let closeWindow;
 
   let data = {
+    abilities: {
+      data: {
+        str: 8,
+        con: 8,
+        dex: 8,
+        int: 8,
+        wis: 8,
+        cha: 8,
+      },
+      mode: "pointbuy",
+      pointBuyBudget: 27,
+    },
     race: {
       uuid: "",
       data: {},
@@ -37,7 +50,7 @@
     },
   };
 
-  let tabs = ["Races", "Class", "Background", "Review"];
+  let tabs = ["Races", "Class", "Abilities", "Background", "Review"];
   let currentTab = "Races";
 
   async function createCharacter(event) {
@@ -200,6 +213,10 @@
 
   {#if currentTab === "Class"}
     <ClassTab bind:data />
+  {/if}
+
+  {#if currentTab === "Abilities"}
+    <AbilityScoreTab bind:data />
   {/if}
 
   {#if currentTab === "Background"}

--- a/src/components/CharacterCreation.svelte
+++ b/src/components/CharacterCreation.svelte
@@ -13,17 +13,20 @@
   let data = {
     abilities: {
       data: {
-        str: 8,
-        con: 8,
-        dex: 8,
-        int: 8,
-        wis: 8,
-        cha: 8,
+        abilities: {
+          str: 8,
+          con: 8,
+          dex: 8,
+          int: 8,
+          wis: 8,
+          cha: 8,
+        },
       },
       mode: "pointbuy",
       pointBuyBudget: 27,
       rolledScores: [],
       availableScores: [],
+      decisionData: {},
     },
     race: {
       uuid: "",
@@ -84,9 +87,8 @@
     const mergeData = Object.keys(data).reduce(dataReducer, {});
 
     if (mergeData.abilities) {
-      for (const [ability, increase] of Object.entries(mergeData.abilities)) {
-        actorData[`data.abilities.${ability}.value`] =
-          actor.data.data.abilities[ability].value + increase;
+      for (const [ability, value] of Object.entries(mergeData.abilities)) {
+        actorData[`data.abilities.${ability}.value`] = value;
       }
     }
 

--- a/src/components/CharacterCreation.svelte
+++ b/src/components/CharacterCreation.svelte
@@ -51,8 +51,6 @@
       decisionData: {},
     },
   };
-  $: console.log(data.abilities.rolledScores);
-  $: console.log(data.abilities.availableScores);
 
   let tabs = ["Races", "Class", "Abilities", "Background", "Review"];
   let currentTab = "Races";

--- a/src/components/LevelUp.svelte
+++ b/src/components/LevelUp.svelte
@@ -101,6 +101,10 @@
     for (const subclass in subclassData) {
       const subclassFeatures = subclassData[subclass]["features"];
 
+      if (!subclassFeatures) {
+        continue;
+      }
+
       if (Object.keys(subclassFeatures).length === 0) {
         continue;
       }

--- a/src/utils/rollStats.js
+++ b/src/utils/rollStats.js
@@ -1,0 +1,113 @@
+function rollStats() {
+  let statString = `4d6kh3`;
+  let stats = Array(6)
+    .fill(0)
+    .map((e) => new Roll(statString).roll())
+    .sort((a, b) => {
+      return b.total - a.total;
+    });
+
+  let total_average = 0,
+    total_low = 0,
+    total_high = 0,
+    total_header = 0,
+    average_kept = 0,
+    average_change = 0;
+
+  average_kept = average(
+    stats.map(
+      (x) => x.terms[0].results.filter((i) => i?.discarded !== true && i?.rerolled !== true).length
+    )
+  );
+  average_change = average(
+    stats.map(
+      (x) => x.terms[0].results.filter((i) => i?.discarded === true || i?.rerolled === true).length
+    )
+  );
+
+  total_average = (stats[0].terms[0].faces / 2 + 0.5) * average_kept + average_change;
+  total_low = Math.ceil(total_average - stats[0].terms[0].faces / 2);
+  total_high = Math.ceil(total_average + stats[0].terms[0].faces / 2);
+
+  total_header = Math.max(...stats.map((x) => x.terms[0].results.length));
+
+  let content = `
+  <table style="text-align:center">
+    <tr>
+      <th colspan="${total_header + 2}">New Ability Scores</th>
+    </tr>
+    <tr style="border-bottom:1px solid #000">
+      <th colspan="${total_header + 2}">${statString}</th>
+    </tr>
+    <tr style="border-bottom:1px solid #000">
+      ${Array(total_header)
+        .fill(0)
+        .map((v, i) => `<th>D${i + 1}</th>`)
+        .join(``)}
+      <th style ="border-left:1px solid #000">Total</th>
+      <th style ="border-left:1px solid #000">Mod</th>
+    </tr>
+    ${stats
+      .map((stat, stat_i) => {
+        let return_value = `<tr>`;
+        return_value += Array(total_header)
+          .fill(0)
+          .map((v, i) => {
+            let roll = stat.terms[0].results[i]?.result;
+            let discard = stat.terms[0].results[i]?.discarded;
+            let rerolled = stat.terms[0].results[i]?.rerolled;
+
+            if (roll) {
+              if (discard)
+                return `<td style="${colorSetter(roll, 1, stat.terms[0].faces)}">${roll}-d</td>`;
+              if (rerolled)
+                return `<td style="${colorSetter(roll, 1, stat.terms[0].faces)}">${roll}-r</td>`;
+
+              return `<td style="${colorSetter(roll, 1, stat.terms[0].faces)}">${roll}</td>`;
+            } else {
+              return `<td></td>`;
+            }
+          })
+          .join(``);
+
+        return (return_value += `<td style="border-left:1px solid #000; ${colorSetter(
+          stat.total,
+          total_low,
+          total_high
+        )}">${stat.total}</td><td style="border-left:1px solid #000; ${colorSetter(
+          Math.floor((stat.total - 10) / 2),
+          -1,
+          1
+        )}">${Math.floor((stat.total - 10) / 2)}</td></tr>`);
+      })
+      .join(``)}
+    <tr>
+      <td colspan="${total_header}" style="border-top:1px solid #000;"> Sum : </td>
+      <td style="border-left:1px solid #000; border-top:1px solid #000;">${stats.reduce(
+        (a, c, i) => a + c.total,
+        0
+      )}</td>
+      <td style="border-left:1px solid #000; border-top:1px solid #000;">${stats.reduce(
+        (a, c, i) => a + Math.floor((c.total - 10) / 2),
+        0
+      )}</td>
+    </tr>
+  </table>
+  `;
+
+  ChatMessage.create({ content });
+
+  return stats.map((stat) => stat.total);
+}
+
+function colorSetter(number, low, high) {
+  if (number <= low) return `color:red`;
+  if (number >= high) return `color:green`;
+  return ``;
+}
+
+function average(nums) {
+  return nums.reduce((a, b) => a + b) / nums.length;
+}
+
+export default rollStats;


### PR DESCRIPTION
## What's the problem(s) we're trying to solve?
Add ability score selection to character creation
## How does this change solve the problem(s)?
- Add `AbilityScoreTab` component to represent choosing a class
  - This is different from the `AbilitiesTab` component used for leveling up because ability score selection is different at character creation vs leveling up
  - This tab supports the following methods:
    - Standard Array
    - Point Buy
    - Roll for Stats (6 * 4d6dl)
    - Manual Entry 
## What side effects does this change have?
- Add macro file `rollStats.js` that will generate a chat message with stats when selecting roll stats.
## Screenshot(s)

https://user-images.githubusercontent.com/18728526/120559136-7e070280-c3ce-11eb-9a15-a1a4557de85e.mp4



