### PR TITLE
Rework item selection

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -65,6 +65,10 @@
   transform: scale(1.5);
 }
 
+.character-creation-window button {
+  box-shadow: none;
+}
+
 .header-herosmith-button {
   margin: 4px;
 }

--- a/src/components/ItemCard.svelte
+++ b/src/components/ItemCard.svelte
@@ -52,7 +52,6 @@
     max-width: 300px;
     border-radius: 5px;
     padding: 6px;
-    /* box-shadow: 2px 2px 4px hsl(0deg 0% 0% / 60%); */
     transition: opacity 0.2s ease-in-out, border 0.2s ease-in-out;
     backface-visibility: hidden;
   }
@@ -62,16 +61,6 @@
     margin-right: 10px;
     cursor: pointer;
   }
-
-  /* .item:not(.disabled):hover {
-    cursor: pointer;
-    transform: scale(1.025);
-    box-shadow: 4px 4px 4px hsl(0deg 0% 0% / 60%);
-  } */
-
-  /* .item:not(.disabled):active {
-    box-shadow: inset 2px 2px 4px hsl(0deg 0% 0% / 60%);
-  } */
 
   .disabled {
     opacity: 0.4;
@@ -98,19 +87,6 @@
     cursor: pointer;
     text-shadow: 0 0 10px red;
   }
-
-  /* .more-info:hover {
-    text-shadow: 0 0 10px #782e22;
-  } */
-
-  /* i {
-    color: #7a7971;
-    width: 2em;
-    height: 2em;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  } */
 
   .image {
     margin-right: 10px;

--- a/src/components/ItemCard.svelte
+++ b/src/components/ItemCard.svelte
@@ -16,20 +16,26 @@
   export let uuid;
 </script>
 
-<div class="item" class:disabled class:selected on:click={select}>
+<div class="item" class:selected>
   {#await fromUuid(uuid) then item}
     <div class="row">
-      <div class="select-area">
+      <input
+        class="select-box"
+        type="checkbox"
+        on:click={select}
+        class:disabled
+        {disabled}
+        checked={selected}
+      />
+      <div
+        class="select-area"
+        on:click={() => {
+          new game.dnd5e.applications.ItemSheet5e(item).render(true);
+        }}
+      >
         <img class="image" src={item.img} alt={`${item.name} icon`} />
         <h4 class="name">{item.name}</h4>
       </div>
-      <i
-        class:more-info={!disabled}
-        on:click={() => {
-          if (!disabled) new game.dnd5e.applications.ItemSheet5e(item).render(true);
-        }}
-        class="fas fa-info-circle"
-      />
     </div>
   {/await}
 </div>
@@ -40,28 +46,32 @@
   }
 
   .item {
-    display: grid;
-    grid-template-columns: min-content;
-    border: 2px solid rgba(181, 179, 164, 0.4);
+    display: flex;
+    border: 2px solid #c9c7b8;
     align-items: center;
     max-width: 300px;
     border-radius: 5px;
     padding: 6px;
-    box-shadow: 2px 2px 4px hsl(0deg 0% 0% / 60%);
-    transition: opacity 0.2s ease-in-out, border 0.2s ease-in-out, transform 0.1s ease-in-out,
-      box-shadow 0.1s ease-in-out;
+    /* box-shadow: 2px 2px 4px hsl(0deg 0% 0% / 60%); */
+    transition: opacity 0.2s ease-in-out, border 0.2s ease-in-out;
     backface-visibility: hidden;
   }
 
-  .item:not(.disabled):hover {
+  .select-box {
+    transition: opacity 0.2s ease-in-out;
+    margin-right: 10px;
+    cursor: pointer;
+  }
+
+  /* .item:not(.disabled):hover {
     cursor: pointer;
     transform: scale(1.025);
     box-shadow: 4px 4px 4px hsl(0deg 0% 0% / 60%);
-  }
+  } */
 
-  .item:not(.disabled):active {
+  /* .item:not(.disabled):active {
     box-shadow: inset 2px 2px 4px hsl(0deg 0% 0% / 60%);
-  }
+  } */
 
   .disabled {
     opacity: 0.4;
@@ -84,21 +94,26 @@
     align-items: center;
   }
 
-  .more-info:hover {
-    text-shadow: 0 0 10px #782e22;
+  .select-area:hover {
+    cursor: pointer;
+    text-shadow: 0 0 10px red;
   }
 
-  i {
+  /* .more-info:hover {
+    text-shadow: 0 0 10px #782e22;
+  } */
+
+  /* i {
     color: #7a7971;
     width: 2em;
     height: 2em;
     display: flex;
     align-items: center;
     justify-content: center;
-  }
+  } */
 
   .image {
     margin-right: 10px;
-    max-width: 50px;
+    max-width: 40px;
   }
 </style>

--- a/src/components/ItemGroupCard.svelte
+++ b/src/components/ItemGroupCard.svelte
@@ -19,11 +19,26 @@
   }
 </script>
 
-<div class="item-group-card" class:disabled class:selected on:click={select}>
-  <h4 class="item-group-name">{name}</h4>
+<div class="item-group-card" class:selected>
+  <div class="title">
+    <input
+      class="select-box"
+      type="checkbox"
+      on:click={select}
+      class:disabled
+      {disabled}
+      checked={selected}
+    />
+    <h4 class="item-group-name">{name}</h4>
+  </div>
   {#each Object.entries(countBy(contents)) as [itemUuid, quantity]}
     {#await fromUuid(itemUuid) then item}
-      <div class="row">
+      <div
+        class="select-area"
+        on:click={() => {
+          new game.dnd5e.applications.ItemSheet5e(item).render(true);
+        }}
+      >
         <img class="image" src={item.img} alt={`${item.name} icon`} />
         <span class="name">{item.name} (x{quantity})</span>
       </div>
@@ -32,26 +47,33 @@
 </div>
 
 <style>
+  input {
+    margin-left: 0px;
+    margin-right: 10px;
+    transition: opacity 0.2s ease-in-out;
+  }
+
+  input:hover {
+    cursor: pointer;
+  }
+
+  h4 {
+    margin: 0;
+  }
+
   .item-group-card {
     border: 2px solid rgba(181, 179, 164, 0.4);
     align-items: center;
     max-width: 300px;
     border-radius: 5px;
     padding: 6px;
-    box-shadow: 2px 2px 4px hsl(0deg 0% 0% / 60%);
-    transition: opacity 0.2s ease-in-out, border 0.2s ease-in-out, transform 0.1s ease-in-out,
-      box-shadow 0.1s ease-in-out;
+    transition: opacity 0.2s ease-in-out, border 0.2s ease-in-out, transform 0.1s ease-in-out;
     backface-visibility: hidden;
   }
 
-  .item-group-card:not(.disabled):hover {
-    cursor: pointer;
-    transform: scale(1.025);
-    box-shadow: 4px 4px 4px hsl(0deg 0% 0% / 60%);
-  }
-
-  .item-group-card:not(.disabled):active {
-    box-shadow: inset 2px 2px 4px hsl(0deg 0% 0% / 60%);
+  .title {
+    display: flex;
+    align-items: center;
   }
 
   .name {
@@ -66,12 +88,17 @@
     border: 2px solid #782e22;
   }
 
-  .row {
+  .select-area {
     display: flex;
     align-items: center;
     grid-column: 2;
     font-size: 16px;
     margin-top: 2px;
+  }
+
+  .select-area:hover {
+    cursor: pointer;
+    text-shadow: 0 0 10px red;
   }
 
   img {

--- a/src/components/TextCard.svelte
+++ b/src/components/TextCard.svelte
@@ -17,7 +17,15 @@
   export let data = {};
 </script>
 
-<div class="item" class:disabled class:selected on:click={select}>
+<div class="item" class:selected>
+  <input
+    class="select-box"
+    type="checkbox"
+    on:click={select}
+    class:disabled
+    {disabled}
+    checked={selected}
+  />
   <h4 class="name">{text}</h4>
 </div>
 
@@ -27,22 +35,26 @@
   }
 
   .item {
-    text-align: center;
+    display: flex;
     width: 100%;
     border: 2px solid #c9c7b8;
     border-radius: 5px;
     padding: 6px;
-    box-shadow: 2px 2px 4px hsl(0deg 0% 0% / 60%);
-    transition: opacity 0.2s ease-in-out, border 0.2s ease-in-out, transform 0.1s ease-in-out,
-      box-shadow 0.1s ease-in-out;
+    transition: opacity 0.2s ease-in-out, border 0.2s ease-in-out;
     backface-visibility: hidden;
   }
 
-  .item:not(.disabled):hover {
+  .select-box {
+    transition: opacity 0.1s ease-in-out;
+    margin-right: 10px;
+    cursor: pointer;
+  }
+
+  /* .item:not(.disabled):hover {
     cursor: pointer;
     transform: scale(1.025);
     box-shadow: 4px 4px 4px hsl(0deg 0% 0% / 60%);
-  }
+  } */
 
   .item:not(.disabled):active {
     box-shadow: inset 2px 2px 4px hsl(0deg 0% 0% / 60%);

--- a/src/components/TextCard.svelte
+++ b/src/components/TextCard.svelte
@@ -50,16 +50,6 @@
     cursor: pointer;
   }
 
-  /* .item:not(.disabled):hover {
-    cursor: pointer;
-    transform: scale(1.025);
-    box-shadow: 4px 4px 4px hsl(0deg 0% 0% / 60%);
-  } */
-
-  .item:not(.disabled):active {
-    box-shadow: inset 2px 2px 4px hsl(0deg 0% 0% / 60%);
-  }
-
   .disabled {
     opacity: 0.4;
   }


### PR DESCRIPTION
## What's the problem(s) we're trying to solve?
We want the user to be able to click on the title of the icon to get more info about it
## How does this change solve the problem(s)?
- Add `input` checkbox to `ItemCard`, `TextCard` and `ItemGroupCard` components
- This checkbox will trigger the select when clicked and will fade when disabled instead of the whole card
- This allows the user to click on the item title and get the info instead of relying on the question mark icon
## Screenshot(s)
<img width="710" alt="Screen Shot 2021-07-04 at 2 15 40 PM" src="https://user-images.githubusercontent.com/18728526/124395695-7d1a0700-dcd3-11eb-9d2a-526595de0c6e.png">
<img width="489" alt="Screen Shot 2021-07-04 at 2 15 45 PM" src="https://user-images.githubusercontent.com/18728526/124395696-7d1a0700-dcd3-11eb-8656-2453a110f3e8.png">
<img width="707" alt="Screen Shot 2021-07-04 at 2 27 29 PM" src="https://user-images.githubusercontent.com/18728526/124395778-fd406c80-dcd3-11eb-987f-c204d3fc3d70.png">

