### PR TITLE
Create spells tab

### DIFF
--- a/src/components/CharacterCreation.svelte
+++ b/src/components/CharacterCreation.svelte
@@ -5,6 +5,7 @@
   import ReviewTab from "components/ReviewTab.svelte";
   import AbilityScoreTab from "components/AbilityScoreTab.svelte";
   import EquipmentTab from "components/EquipmentTab.svelte";
+  import SpellTab from "components/SpellTab.svelte";
   import { capitalize } from "utils/utils.js";
   import { mergeWith, countBy } from "lodash";
   import { mergeCustomizer } from "utils/utils.js";
@@ -66,9 +67,13 @@
       },
       decisionData: {},
     },
+    spells: {
+      data: {},
+      decisionData: {},
+    },
   };
 
-  let tabs = ["Races", "Class", "Abilities", "Background", "Equipment", "Review"];
+  let tabs = ["Races", "Class", "Abilities", "Background", "Equipment", "Spells", "Review"];
   let currentTab = "Races";
 
   async function createCharacter(event) {
@@ -253,6 +258,10 @@
 
   {#if currentTab === "Equipment"}
     <EquipmentTab bind:data bind:editorOptions />
+  {/if}
+
+  {#if currentTab === "Spells"}
+    <SpellTab bind:data bind:editorOptions />
   {/if}
 
   {#if currentTab === "Review"}

--- a/src/components/ClassTab.svelte
+++ b/src/components/ClassTab.svelte
@@ -24,6 +24,14 @@
               data: {},
               decisionData: {},
             };
+            data.classEquipment = {
+              data: {},
+              decisionData: {},
+            };
+            data.spells = {
+              data: {},
+              decisionData: {},
+            };
           } else {
             data.class = {
               uuid: classUuid,

--- a/src/components/SpellTab.svelte
+++ b/src/components/SpellTab.svelte
@@ -1,0 +1,33 @@
+<script>
+  import Choice from "components/Choice.svelte";
+  import CLASSES from "data/classes.js";
+
+  import { fade } from "svelte/transition";
+  import { cubicInOut } from "svelte/easing";
+
+  export let data;
+  export let level = 1;
+  export let editorOptions;
+</script>
+
+<div class="spell-tab">
+  <h2>Spells</h2>
+  {#if !data.class.uuid}
+    <p class="error">Select a class to view spells</p>
+  {/if}
+
+  <!-- Class Spell Choices -->
+  {#if CLASSES[data.class.uuid]?.spells?.[level]?.["choices"]}
+    <div class="choices" transition:fade|local={{ duration: 200, easing: cubicInOut }}>
+      {#each CLASSES[data.class.uuid]["spells"][level]["choices"] as choice, i}
+        <Choice {choice} bind:data={data.spells.decisionData[i]} />
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .error {
+    color: red;
+  }
+</style>

--- a/src/components/SpellTab.svelte
+++ b/src/components/SpellTab.svelte
@@ -23,6 +23,9 @@
         <Choice {choice} bind:data={data.spells.decisionData[i]} />
       {/each}
     </div>
+  {:else if data.class.uuid}
+    <!-- Class does not have spells -->
+    <p class="error">Your class is not eligible for spells</p>
   {/if}
 </div>
 

--- a/src/data/classes.js
+++ b/src/data/classes.js
@@ -390,6 +390,22 @@ const CLASSES = {
         ],
       },
     },
+    spells: {
+      1: {
+        choices: [
+          {
+            name: "Cantrips",
+            choose: 3,
+            options: classSpellOptions("cleric", 0),
+          },
+          {
+            name: "Level 1 Spells",
+            choose: 2,
+            options: classSpellOptions("cleric", 1),
+          },
+        ],
+      },
+    },
   },
 
   // Druid
@@ -546,6 +562,22 @@ const CLASSES = {
                 },
               },
             ],
+          },
+        ],
+      },
+    },
+    spells: {
+      1: {
+        choices: [
+          {
+            name: "Cantrips",
+            choose: 2,
+            options: classSpellOptions("druid", 0),
+          },
+          {
+            name: "Level 1 Spells",
+            choose: 2,
+            options: classSpellOptions("druid", 1),
           },
         ],
       },
@@ -1301,6 +1333,22 @@ const CLASSES = {
         ],
       },
     },
+    spells: {
+      1: {
+        choices: [
+          {
+            name: "Cantrips",
+            choose: 4,
+            options: classSpellOptions("sorcerer", 0),
+          },
+          {
+            name: "Level 1 Spells",
+            choose: 2,
+            options: classSpellOptions("sorcerer", 1),
+          },
+        ],
+      },
+    },
   },
 
   // Warlock
@@ -1433,6 +1481,22 @@ const CLASSES = {
         ],
       },
     },
+    spells: {
+      1: {
+        choices: [
+          {
+            name: "Cantrips",
+            choose: 2,
+            options: classSpellOptions("warlock", 0),
+          },
+          {
+            name: "Level 1 Spells",
+            choose: 2,
+            options: classSpellOptions("warlock", 1),
+          },
+        ],
+      },
+    },
   },
 
   // Wizard
@@ -1552,6 +1616,22 @@ const CLASSES = {
             name: "Scholar's Pack or Explorer's Pack",
             choose: 1,
             options: itemPackOptions(["scholar", "explorer"]),
+          },
+        ],
+      },
+    },
+    spells: {
+      1: {
+        choices: [
+          {
+            name: "Cantrips",
+            choose: 3,
+            options: classSpellOptions("wizard", 0),
+          },
+          {
+            name: "Level 1 Spells",
+            choose: 2,
+            options: classSpellOptions("wizard", 1),
           },
         ],
       },

--- a/src/data/classes.js
+++ b/src/data/classes.js
@@ -1,6 +1,7 @@
 import skillOptions from "data/skillOptions.js";
 import toolOptions from "data/toolOptions.js";
 import itemOptions from "data/itemOptions.js";
+import { classSpellOptions } from "data/spellOptions.js";
 import itemPackOptions from "data/itemPackOptions.js";
 
 const CLASSES = {
@@ -221,6 +222,23 @@ const CLASSES = {
             name: "Musical Instrument",
             choose: 1,
             options: Object.values(itemOptions("tools.instruments")),
+          },
+        ],
+      },
+    },
+
+    spells: {
+      1: {
+        choices: [
+          {
+            name: "Cantrips",
+            choose: 2,
+            options: classSpellOptions("bard", 0),
+          },
+          {
+            name: "Level 1 Spells",
+            choose: 4,
+            options: classSpellOptions("bard", 1),
           },
         ],
       },

--- a/src/data/spellOptions.js
+++ b/src/data/spellOptions.js
@@ -1,0 +1,2832 @@
+const spells = {
+  acidarrow: {
+    name: "Acid Arrow",
+    data: {
+      items: ["Compendium.dnd5e.spells.4H6YgYdKgnX6ZQ8M"],
+    },
+  },
+  acidsplash: {
+    name: "Acid Splash",
+    data: {
+      items: ["Compendium.dnd5e.spells.JLTQyqXEaJDrTXyW"],
+    },
+  },
+  aid: {
+    name: "Aid",
+    data: {
+      items: ["Compendium.dnd5e.spells.Opwh2PdX4runSBlm"],
+    },
+  },
+  alarm: {
+    name: "Alarm",
+    data: {
+      items: ["Compendium.dnd5e.spells.7p9IuWrSWFgfyQo2"],
+    },
+  },
+  alterself: {
+    name: "Alter Self",
+    data: {
+      items: ["Compendium.dnd5e.spells.8RTDOt80u8aBv9qx"],
+    },
+  },
+  animalfriendship: {
+    name: "Animal Friendship",
+    data: {
+      items: ["Compendium.dnd5e.spells.hDOENzjuj5WpLq7B"],
+    },
+  },
+  animalmessenger: {
+    name: "Animal Messenger",
+    data: {
+      items: ["Compendium.dnd5e.spells.X8w9EzYLGc4vQ1H2"],
+    },
+  },
+  animalshapes: {
+    name: "Animal Shapes",
+    data: {
+      items: ["Compendium.dnd5e.spells.ohqAIBg6de989CIo"],
+    },
+  },
+  animatedead: {
+    name: "Animate Dead",
+    data: {
+      items: ["Compendium.dnd5e.spells.oyE5nVppa5mde5gT"],
+    },
+  },
+  animateobjects: {
+    name: "Animate Objects",
+    data: {
+      items: ["Compendium.dnd5e.spells.ATo0Eb63TDtnu6iA"],
+    },
+  },
+  antilifeshell: {
+    name: "Antilife Shell",
+    data: {
+      items: ["Compendium.dnd5e.spells.wXzkqpeFP8eWgJzK"],
+    },
+  },
+  antimagicfield: {
+    name: "Antimagic Field",
+    data: {
+      items: ["Compendium.dnd5e.spells.Eon0jzGzQRNluTPQ"],
+    },
+  },
+  "antipathy/sympathy": {
+    name: "Antipathy/Sympathy",
+    data: {
+      items: ["Compendium.dnd5e.spells.GJ2WYm3SQFR0winH"],
+    },
+  },
+  arcaneeye: {
+    name: "Arcane Eye",
+    data: {
+      items: ["Compendium.dnd5e.spells.ImlCJQwR1VL40Qem"],
+    },
+  },
+  arcanehand: {
+    name: "Arcane Hand",
+    data: {
+      items: ["Compendium.dnd5e.spells.a2KJHCIbY5Mi4Dmn"],
+    },
+  },
+  arcanelock: {
+    name: "Arcane Lock",
+    data: {
+      items: ["Compendium.dnd5e.spells.8cse7rit0oswRPUP"],
+    },
+  },
+  arcanesword: {
+    name: "Arcane Sword",
+    data: {
+      items: ["Compendium.dnd5e.spells.LTDNWoFVJNLjiiNa"],
+    },
+  },
+  "arcanist'smagicaura": {
+    name: "Arcanist's Magic Aura",
+    data: {
+      items: ["Compendium.dnd5e.spells.RvEqsD89Zvd5yex4"],
+    },
+  },
+  astralprojection: {
+    name: "Astral Projection",
+    data: {
+      items: ["Compendium.dnd5e.spells.TIoadMIsUKD4edXi"],
+    },
+  },
+  augury: {
+    name: "Augury",
+    data: {
+      items: ["Compendium.dnd5e.spells.4v2H3hHb3Ph9XLNd"],
+    },
+  },
+  awaken: {
+    name: "Awaken",
+    data: {
+      items: ["Compendium.dnd5e.spells.MCEpGpvovcXagwQS"],
+    },
+  },
+  bane: {
+    name: "Bane",
+    data: {
+      items: ["Compendium.dnd5e.spells.95K2aUhAGV9qXjnf"],
+    },
+  },
+  banishment: {
+    name: "Banishment",
+    data: {
+      items: ["Compendium.dnd5e.spells.pxpb2eOB6bv4phAf"],
+    },
+  },
+  barkskin: {
+    name: "Barkskin",
+    data: {
+      items: ["Compendium.dnd5e.spells.JPwIEfgUPVebr5AH"],
+    },
+  },
+  beaconofhope: {
+    name: "Beacon of Hope",
+    data: {
+      items: ["Compendium.dnd5e.spells.ZU9d6woBdUP8pIPt"],
+    },
+  },
+  bestowcurse: {
+    name: "Bestow Curse",
+    data: {
+      items: ["Compendium.dnd5e.spells.pO4zGe5LmFIYqJiL"],
+    },
+  },
+  blacktentacles: {
+    name: "Black Tentacles",
+    data: {
+      items: ["Compendium.dnd5e.spells.DGONTFbk5eORs5qv"],
+    },
+  },
+  bladebarrier: {
+    name: "Blade Barrier",
+    data: {
+      items: ["Compendium.dnd5e.spells.dLJhxDfeyOsc3zsY"],
+    },
+  },
+  bless: {
+    name: "Bless",
+    data: {
+      items: ["Compendium.dnd5e.spells.8dzaICjGy6mTUaUr"],
+    },
+  },
+  blight: {
+    name: "Blight",
+    data: {
+      items: ["Compendium.dnd5e.spells.pybg5MNc3lkerH4Y"],
+    },
+  },
+  "blindness/deafness": {
+    name: "Blindness/Deafness",
+    data: {
+      items: ["Compendium.dnd5e.spells.zwGsAv6kmwzYGhh3"],
+    },
+  },
+  blink: {
+    name: "Blink",
+    data: {
+      items: ["Compendium.dnd5e.spells.GSvLWcdCZLQkilXT"],
+    },
+  },
+  blur: {
+    name: "Blur",
+    data: {
+      items: ["Compendium.dnd5e.spells.UDUnlfPsOAbq2RSE"],
+    },
+  },
+  brandingsmite: {
+    name: "Branding Smite",
+    data: {
+      items: ["Compendium.dnd5e.spells.7UwUjJ6owIQkEPrs"],
+    },
+  },
+  burninghands: {
+    name: "Burning Hands",
+    data: {
+      items: ["Compendium.dnd5e.spells.5SuJewoa1CRWaj1F"],
+    },
+  },
+  calllightning: {
+    name: "Call Lightning",
+    data: {
+      items: ["Compendium.dnd5e.spells.ehvmg9U9fcMEhE4z"],
+    },
+  },
+  calmemotions: {
+    name: "Calm Emotions",
+    data: {
+      items: ["Compendium.dnd5e.spells.3MYDjS6k9IYL0aTj"],
+    },
+  },
+  chainlightning: {
+    name: "Chain Lightning",
+    data: {
+      items: ["Compendium.dnd5e.spells.QbTxN5dWIbYZ4jLU"],
+    },
+  },
+  charmperson: {
+    name: "Charm Person",
+    data: {
+      items: ["Compendium.dnd5e.spells.eS7XnnApoxRxYXPs"],
+    },
+  },
+  chilltouch: {
+    name: "Chill Touch",
+    data: {
+      items: ["Compendium.dnd5e.spells.vrN18tbTw7io5MWd"],
+    },
+  },
+  circleofdeath: {
+    name: "Circle of Death",
+    data: {
+      items: ["Compendium.dnd5e.spells.KeunEkg1JYbOCOhV"],
+    },
+  },
+  clairvoyance: {
+    name: "Clairvoyance",
+    data: {
+      items: ["Compendium.dnd5e.spells.cg50KpBkBdPK6vPL"],
+    },
+  },
+  clone: {
+    name: "Clone",
+    data: {
+      items: ["Compendium.dnd5e.spells.h830iyqParFleNqR"],
+    },
+  },
+  cloudkill: {
+    name: "Cloudkill",
+    data: {
+      items: ["Compendium.dnd5e.spells.LkvI11Uue774QBKZ"],
+    },
+  },
+  colorspray: {
+    name: "Color Spray",
+    data: {
+      items: ["Compendium.dnd5e.spells.LWTUqKkUQdMAmOe0"],
+    },
+  },
+  command: {
+    name: "Command",
+    data: {
+      items: ["Compendium.dnd5e.spells.arzCrMRgcNiQuh43"],
+    },
+  },
+  commune: {
+    name: "Commune",
+    data: {
+      items: ["Compendium.dnd5e.spells.d54VDyFulD9xxY7J"],
+    },
+  },
+  communewithnature: {
+    name: "Commune with Nature",
+    data: {
+      items: ["Compendium.dnd5e.spells.dp6xny4v8PDoIGjh"],
+    },
+  },
+  comprehendlanguages: {
+    name: "Comprehend Languages",
+    data: {
+      items: ["Compendium.dnd5e.spells.4dSvfvTy2ZIJ3K4k"],
+    },
+  },
+  compulsion: {
+    name: "Compulsion",
+    data: {
+      items: ["Compendium.dnd5e.spells.P6f1PPKPd9BCb742"],
+    },
+  },
+  coneofcold: {
+    name: "Cone of Cold",
+    data: {
+      items: ["Compendium.dnd5e.spells.RpKjTlYASrfqUPVA"],
+    },
+  },
+  confusion: {
+    name: "Confusion",
+    data: {
+      items: ["Compendium.dnd5e.spells.9hQXdMSmerkTsHDe"],
+    },
+  },
+  conjureanimals: {
+    name: "Conjure Animals",
+    data: {
+      items: ["Compendium.dnd5e.spells.1Drt0SHxbEAHxprN"],
+    },
+  },
+  conjurecelestial: {
+    name: "Conjure Celestial",
+    data: {
+      items: ["Compendium.dnd5e.spells.XT7nzJmVGgv73uaf"],
+    },
+  },
+  conjureelemental: {
+    name: "Conjure Elemental",
+    data: {
+      items: ["Compendium.dnd5e.spells.1LkZvINag7KqBmDR"],
+    },
+  },
+  conjurefey: {
+    name: "Conjure Fey",
+    data: {
+      items: ["Compendium.dnd5e.spells.yN3XZZujhR4aVvPa"],
+    },
+  },
+  conjureminorelementals: {
+    name: "Conjure Minor Elementals",
+    data: {
+      items: ["Compendium.dnd5e.spells.KgEw3sDr39C6g8nY"],
+    },
+  },
+  conjurewoodlandbeings: {
+    name: "Conjure Woodland Beings",
+    data: {
+      items: ["Compendium.dnd5e.spells.dEfSELiY1eO3cpX9"],
+    },
+  },
+  contactotherplane: {
+    name: "Contact Other Plane",
+    data: {
+      items: ["Compendium.dnd5e.spells.dSTu1MaPhBqPITwM"],
+    },
+  },
+  contagion: {
+    name: "Contagion",
+    data: {
+      items: ["Compendium.dnd5e.spells.CjIq8Ed7bu3vVwT1"],
+    },
+  },
+  contingency: {
+    name: "Contingency",
+    data: {
+      items: ["Compendium.dnd5e.spells.4smlOvpF5AQHcyg1"],
+    },
+  },
+  continualflame: {
+    name: "Continual Flame",
+    data: {
+      items: ["Compendium.dnd5e.spells.MK6gpQMeDFo0cP9f"],
+    },
+  },
+  controlwater: {
+    name: "Control Water",
+    data: {
+      items: ["Compendium.dnd5e.spells.7fFHlBk3UNX8gPKL"],
+    },
+  },
+  controlweather: {
+    name: "Control Weather",
+    data: {
+      items: ["Compendium.dnd5e.spells.ZPd73HtKF3At11jh"],
+    },
+  },
+  counterspell: {
+    name: "Counterspell",
+    data: {
+      items: ["Compendium.dnd5e.spells.Ek45cBpVXvJdv1Qy"],
+    },
+  },
+  createfoodandwater: {
+    name: "Create Food and Water",
+    data: {
+      items: ["Compendium.dnd5e.spells.BV0mpbHh29IbbIj5"],
+    },
+  },
+  createordestroywater: {
+    name: "Create or Destroy Water",
+    data: {
+      items: ["Compendium.dnd5e.spells.a3XtAO5n2GrqiAh5"],
+    },
+  },
+  createundead: {
+    name: "Create Undead",
+    data: {
+      items: ["Compendium.dnd5e.spells.E4NXux0RHvME1XgP"],
+    },
+  },
+  creation: {
+    name: "Creation",
+    data: {
+      items: ["Compendium.dnd5e.spells.lnaGnxMzpYnbw1uU"],
+    },
+  },
+  curewounds: {
+    name: "Cure Wounds",
+    data: {
+      items: ["Compendium.dnd5e.spells.uUWb1wZgtMou0TVP"],
+    },
+  },
+  dancinglights: {
+    name: "Dancing Lights",
+    data: {
+      items: ["Compendium.dnd5e.spells.CAxSzHWizrafT033"],
+    },
+  },
+  darkness: {
+    name: "Darkness",
+    data: {
+      items: ["Compendium.dnd5e.spells.S7VbUetIfVT7B6Eq"],
+    },
+  },
+  darkvision: {
+    name: "Darkvision",
+    data: {
+      items: ["Compendium.dnd5e.spells.hJ6ZiA3fpoY8v9cp"],
+    },
+  },
+  daylight: {
+    name: "Daylight",
+    data: {
+      items: ["Compendium.dnd5e.spells.BP3GCwa66IAw1yTG"],
+    },
+  },
+  deathward: {
+    name: "Death Ward",
+    data: {
+      items: ["Compendium.dnd5e.spells.VtCXMdyM6mAdIJZb"],
+    },
+  },
+  delayedblastfireball: {
+    name: "Delayed Blast Fireball",
+    data: {
+      items: ["Compendium.dnd5e.spells.AoTTjapz1FsGOIZz"],
+    },
+  },
+  demiplane: {
+    name: "Demiplane",
+    data: {
+      items: ["Compendium.dnd5e.spells.xNM9CzQQr2CieM4B"],
+    },
+  },
+  detectevilandgood: {
+    name: "Detect Evil and Good",
+    data: {
+      items: ["Compendium.dnd5e.spells.Mzh95utKDPIrjiH8"],
+    },
+  },
+  detectmagic: {
+    name: "Detect Magic",
+    data: {
+      items: ["Compendium.dnd5e.spells.ghXTfe7sgCbgf1Q8"],
+    },
+  },
+  detectpoisonanddisease: {
+    name: "Detect Poison and Disease",
+    data: {
+      items: ["Compendium.dnd5e.spells.2skfDtglk1mGrb3l"],
+    },
+  },
+  detectthoughts: {
+    name: "Detect Thoughts",
+    data: {
+      items: ["Compendium.dnd5e.spells.ppWAAEul0QHtm4er"],
+    },
+  },
+  dimensiondoor: {
+    name: "Dimension Door",
+    data: {
+      items: ["Compendium.dnd5e.spells.A4RsPuSvB9wFtz1j"],
+    },
+  },
+  disguiseself: {
+    name: "Disguise Self",
+    data: {
+      items: ["Compendium.dnd5e.spells.A3q2gTNqG6fvNGrv"],
+    },
+  },
+  disintegrate: {
+    name: "Disintegrate",
+    data: {
+      items: ["Compendium.dnd5e.spells.HBHbOGKNVVprSlwn"],
+    },
+  },
+  dispelevilandgood: {
+    name: "Dispel Evil and Good",
+    data: {
+      items: ["Compendium.dnd5e.spells.TkJ8Wtg1L7TZtspm"],
+    },
+  },
+  dispelmagic: {
+    name: "Dispel Magic",
+    data: {
+      items: ["Compendium.dnd5e.spells.15Fa6q1nH27XfbR8"],
+    },
+  },
+  divination: {
+    name: "Divination",
+    data: {
+      items: ["Compendium.dnd5e.spells.XqzXSKNR75ZdYTA9"],
+    },
+  },
+  divinefavor: {
+    name: "Divine Favor",
+    data: {
+      items: ["Compendium.dnd5e.spells.8MICCMeOXT3aJUy9"],
+    },
+  },
+  divineword: {
+    name: "Divine Word",
+    data: {
+      items: ["Compendium.dnd5e.spells.T1vpZLam7LezjToj"],
+    },
+  },
+  dominatebeast: {
+    name: "Dominate Beast",
+    data: {
+      items: ["Compendium.dnd5e.spells.LrPvWHBPmiMQQsKB"],
+    },
+  },
+  dominatemonster: {
+    name: "Dominate Monster",
+    data: {
+      items: ["Compendium.dnd5e.spells.eEpy1ONlXumKS1mp"],
+    },
+  },
+  dominateperson: {
+    name: "Dominate Person",
+    data: {
+      items: ["Compendium.dnd5e.spells.91Sw6vOIaO7U8DvM"],
+    },
+  },
+  dream: {
+    name: "Dream",
+    data: {
+      items: ["Compendium.dnd5e.spells.kSPRpeIx3w3nihrF"],
+    },
+  },
+  druidcraft: {
+    name: "Druidcraft",
+    data: {
+      items: ["Compendium.dnd5e.spells.SbSvZKkJASyk8jKo"],
+    },
+  },
+  earthquake: {
+    name: "Earthquake",
+    data: {
+      items: ["Compendium.dnd5e.spells.x5JNBSyIBBZsjcGT"],
+    },
+  },
+  eldritchblast: {
+    name: "Eldritch Blast",
+    data: {
+      items: ["Compendium.dnd5e.spells.Z9p1vezIn95jw1Yw"],
+    },
+  },
+  enhanceability: {
+    name: "Enhance Ability",
+    data: {
+      items: ["Compendium.dnd5e.spells.9eOZDBImVKxbeOyZ"],
+    },
+  },
+  "enlarge/reduce": {
+    name: "Enlarge/Reduce",
+    data: {
+      items: ["Compendium.dnd5e.spells.WahI41a3goVUg0x1"],
+    },
+  },
+  entangle: {
+    name: "Entangle",
+    data: {
+      items: ["Compendium.dnd5e.spells.gMrWeG8fMDPRFiVe"],
+    },
+  },
+  enthrall: {
+    name: "Enthrall",
+    data: {
+      items: ["Compendium.dnd5e.spells.30ZgXtijJVCxQk5N"],
+    },
+  },
+  etherealness: {
+    name: "Etherealness",
+    data: {
+      items: ["Compendium.dnd5e.spells.PQuEgKyCdovOvhqN"],
+    },
+  },
+  expeditiousretreat: {
+    name: "Expeditious Retreat",
+    data: {
+      items: ["Compendium.dnd5e.spells.zPGohqJRir6MyQ3U"],
+    },
+  },
+  eyebite: {
+    name: "Eyebite",
+    data: {
+      items: ["Compendium.dnd5e.spells.ZRqu3Xh9FmlBCZGy"],
+    },
+  },
+  fabricate: {
+    name: "Fabricate",
+    data: {
+      items: ["Compendium.dnd5e.spells.7Fw7Bf1k3xxDVr5L"],
+    },
+  },
+  faeriefire: {
+    name: "Faerie Fire",
+    data: {
+      items: ["Compendium.dnd5e.spells.nqBDWkVOfcGZt4YU"],
+    },
+  },
+  faithfulhound: {
+    name: "Faithful Hound",
+    data: {
+      items: ["Compendium.dnd5e.spells.SAj03P2WBDiWu7zu"],
+    },
+  },
+  falselife: {
+    name: "False Life",
+    data: {
+      items: ["Compendium.dnd5e.spells.7e3QXF10hLNDEdr6"],
+    },
+  },
+  fear: {
+    name: "Fear",
+    data: {
+      items: ["Compendium.dnd5e.spells.XXUDGFELgoskdOD0"],
+    },
+  },
+  featherfall: {
+    name: "Feather Fall",
+    data: {
+      items: ["Compendium.dnd5e.spells.pub0OWVEB71XQx1n"],
+    },
+  },
+  feeblemind: {
+    name: "Feeblemind",
+    data: {
+      items: ["Compendium.dnd5e.spells.hYCrN82dMJFuJODB"],
+    },
+  },
+  findfamiliar: {
+    name: "Find Familiar",
+    data: {
+      items: ["Compendium.dnd5e.spells.JGT5bNqu9REL7Fuz"],
+    },
+  },
+  findsteed: {
+    name: "Find Steed",
+    data: {
+      items: ["Compendium.dnd5e.spells.5eh2HFbS13078Y3H"],
+    },
+  },
+  findthepath: {
+    name: "Find the Path",
+    data: {
+      items: ["Compendium.dnd5e.spells.cYI4RNNjI5GAmLhy"],
+    },
+  },
+  findtraps: {
+    name: "Find Traps",
+    data: {
+      items: ["Compendium.dnd5e.spells.KrM3oHVv13RAALrS"],
+    },
+  },
+  fingerofdeath: {
+    name: "Finger of Death",
+    data: {
+      items: ["Compendium.dnd5e.spells.HPvZm8YJO91k6Qdg"],
+    },
+  },
+  firebolt: {
+    name: "Fire Bolt",
+    data: {
+      items: ["Compendium.dnd5e.spells.EOmsUcFQJTfG2oio"],
+    },
+  },
+  fireshield: {
+    name: "Fire Shield",
+    data: {
+      items: ["Compendium.dnd5e.spells.avD5XUtkBPQQR97c"],
+    },
+  },
+  firestorm: {
+    name: "Fire Storm",
+    data: {
+      items: ["Compendium.dnd5e.spells.J3uILDYS7MiOfmTJ"],
+    },
+  },
+  fireball: {
+    name: "Fireball",
+    data: {
+      items: ["Compendium.dnd5e.spells.ztgcdrWPshKRpFd0"],
+    },
+  },
+  flameblade: {
+    name: "Flame Blade",
+    data: {
+      items: ["Compendium.dnd5e.spells.Advtckpz1B733bu9"],
+    },
+  },
+  flamestrike: {
+    name: "Flame Strike",
+    data: {
+      items: ["Compendium.dnd5e.spells.5e1xTohkzqFqbYH4"],
+    },
+  },
+  flamingsphere: {
+    name: "Flaming Sphere",
+    data: {
+      items: ["Compendium.dnd5e.spells.FjYE214HTERCRZNm"],
+    },
+  },
+  fleshtostone: {
+    name: "Flesh to Stone",
+    data: {
+      items: ["Compendium.dnd5e.spells.kozNy29b0X6exFhY"],
+    },
+  },
+  floatingdisk: {
+    name: "Floating Disk",
+    data: {
+      items: ["Compendium.dnd5e.spells.bnjXlk13ZRJuf5d0"],
+    },
+  },
+  fly: {
+    name: "Fly",
+    data: {
+      items: ["Compendium.dnd5e.spells.yfbK8gZqESlaoY5t"],
+    },
+  },
+  fogcloud: {
+    name: "Fog Cloud",
+    data: {
+      items: ["Compendium.dnd5e.spells.IBJmWjzbQGu7M4UX"],
+    },
+  },
+  forbiddance: {
+    name: "Forbiddance",
+    data: {
+      items: ["Compendium.dnd5e.spells.64D1gNZ4hx7SWG2x"],
+    },
+  },
+  forcecage: {
+    name: "Forcecage",
+    data: {
+      items: ["Compendium.dnd5e.spells.Y7uWUO4yqUN0JKl0"],
+    },
+  },
+  foresight: {
+    name: "Foresight",
+    data: {
+      items: ["Compendium.dnd5e.spells.6HEEhLdJz32TL4Js"],
+    },
+  },
+  freedomofmovement: {
+    name: "Freedom of Movement",
+    data: {
+      items: ["Compendium.dnd5e.spells.da0a1t2FqaTjRZGT"],
+    },
+  },
+  freezingsphere: {
+    name: "Freezing Sphere",
+    data: {
+      items: ["Compendium.dnd5e.spells.MImfWCzEPRMYD3Xp"],
+    },
+  },
+  gaseousform: {
+    name: "Gaseous Form",
+    data: {
+      items: ["Compendium.dnd5e.spells.2IWiZAJtOGDoKjiz"],
+    },
+  },
+  gate: {
+    name: "Gate",
+    data: {
+      items: ["Compendium.dnd5e.spells.XbwGq5kDJNvAxNXV"],
+    },
+  },
+  geas: {
+    name: "Geas",
+    data: {
+      items: ["Compendium.dnd5e.spells.JQyigMNPiDnGI18b"],
+    },
+  },
+  gentlerepose: {
+    name: "Gentle Repose",
+    data: {
+      items: ["Compendium.dnd5e.spells.n4JDcFKe5ikzYmAc"],
+    },
+  },
+  giantinsect: {
+    name: "Giant Insect",
+    data: {
+      items: ["Compendium.dnd5e.spells.czXrVRx6XYRWsHAi"],
+    },
+  },
+  glibness: {
+    name: "Glibness",
+    data: {
+      items: ["Compendium.dnd5e.spells.1RzxKZzkQOoioxPj"],
+    },
+  },
+  globeofinvulnerability: {
+    name: "Globe of Invulnerability",
+    data: {
+      items: ["Compendium.dnd5e.spells.WmQpxfjZwF3MGUby"],
+    },
+  },
+  glyphofwarding: {
+    name: "Glyph of Warding",
+    data: {
+      items: ["Compendium.dnd5e.spells.pB7XVYwdGNcUG935"],
+    },
+  },
+  goodberry: {
+    name: "Goodberry",
+    data: {
+      items: ["Compendium.dnd5e.spells.Qf6CAZkc7ms4ZY3e"],
+    },
+  },
+  grease: {
+    name: "Grease",
+    data: {
+      items: ["Compendium.dnd5e.spells.etgcR9wqmrhyZ0tx"],
+    },
+  },
+  greaterinvisibility: {
+    name: "Greater Invisibility",
+    data: {
+      items: ["Compendium.dnd5e.spells.tEpDmYZNGc9f5OhJ"],
+    },
+  },
+  greaterrestoration: {
+    name: "Greater Restoration",
+    data: {
+      items: ["Compendium.dnd5e.spells.WzvJ7G3cqvIubsLk"],
+    },
+  },
+  guardianoffaith: {
+    name: "Guardian of Faith",
+    data: {
+      items: ["Compendium.dnd5e.spells.TgHsuhNasPbhu8MO"],
+    },
+  },
+  guardsandwards: {
+    name: "Guards and Wards",
+    data: {
+      items: ["Compendium.dnd5e.spells.yw0tYQkOMCgKZ8Ur"],
+    },
+  },
+  guidance: {
+    name: "Guidance",
+    data: {
+      items: ["Compendium.dnd5e.spells.P7mF2MxSuVJwHRRY"],
+    },
+  },
+  guidingbolt: {
+    name: "Guiding Bolt",
+    data: {
+      items: ["Compendium.dnd5e.spells.7buEm5KhI5lP8m1z"],
+    },
+  },
+  gustofwind: {
+    name: "Gust of Wind",
+    data: {
+      items: ["Compendium.dnd5e.spells.FSMy6VAjDnXY9vWz"],
+    },
+  },
+  hallow: {
+    name: "Hallow",
+    data: {
+      items: ["Compendium.dnd5e.spells.SLxA9QhrggTz0taU"],
+    },
+  },
+  hallucinatoryterrain: {
+    name: "Hallucinatory Terrain",
+    data: {
+      items: ["Compendium.dnd5e.spells.sTIkQK7KuQNOyY0C"],
+    },
+  },
+  harm: {
+    name: "Harm",
+    data: {
+      items: ["Compendium.dnd5e.spells.tMH6Ivn4GmE1naMj"],
+    },
+  },
+  haste: {
+    name: "Haste",
+    data: {
+      items: ["Compendium.dnd5e.spells.Szvk5FEVQW3uhJi5"],
+    },
+  },
+  heal: {
+    name: "Heal",
+    data: {
+      items: ["Compendium.dnd5e.spells.qcYitWoSMTnKkzM1"],
+    },
+  },
+  healingword: {
+    name: "Healing Word",
+    data: {
+      items: ["Compendium.dnd5e.spells.o8Dh7fblk1d16tnO"],
+    },
+  },
+  heatmetal: {
+    name: "Heat Metal",
+    data: {
+      items: ["Compendium.dnd5e.spells.2yHXEcrRbadZDr5M"],
+    },
+  },
+  hellishrebuke: {
+    name: "Hellish Rebuke",
+    data: {
+      items: ["Compendium.dnd5e.spells.22dPoeXfaaAv4K3h"],
+    },
+  },
+  "heroes'feast": {
+    name: "Heroes' Feast",
+    data: {
+      items: ["Compendium.dnd5e.spells.mgFqi0ev8f7Ut19y"],
+    },
+  },
+  heroism: {
+    name: "Heroism",
+    data: {
+      items: ["Compendium.dnd5e.spells.ge3Saet9zPTDyaoL"],
+    },
+  },
+  hideouslaughter: {
+    name: "Hideous Laughter",
+    data: {
+      items: ["Compendium.dnd5e.spells.BQk5Row4NymMnUQl"],
+    },
+  },
+  holdmonster: {
+    name: "Hold Monster",
+    data: {
+      items: ["Compendium.dnd5e.spells.l9Ju5KE7bbn3WpTm"],
+    },
+  },
+  holdperson: {
+    name: "Hold Person",
+    data: {
+      items: ["Compendium.dnd5e.spells.3Lo9boi7P2ro6QV4"],
+    },
+  },
+  holyaura: {
+    name: "Holy Aura",
+    data: {
+      items: ["Compendium.dnd5e.spells.j8S49Rea8b1640Zi"],
+    },
+  },
+  "hunter'smark": {
+    name: "Hunter's Mark",
+    data: {
+      items: ["Compendium.dnd5e.spells.0xmXiPiuYws1OGcX"],
+    },
+  },
+  hypnoticpattern: {
+    name: "Hypnotic Pattern",
+    data: {
+      items: ["Compendium.dnd5e.spells.6g3WLOZ2u0EbaLAd"],
+    },
+  },
+  icestorm: {
+    name: "Ice Storm",
+    data: {
+      items: ["Compendium.dnd5e.spells.WN2LWEljYU6QqnRH"],
+    },
+  },
+  identify: {
+    name: "Identify",
+    data: {
+      items: ["Compendium.dnd5e.spells.3OZnNhunvRtPOQmH"],
+    },
+  },
+  illusoryscript: {
+    name: "Illusory Script",
+    data: {
+      items: ["Compendium.dnd5e.spells.82jM6qD9axLJsTrH"],
+    },
+  },
+  imprisonment: {
+    name: "Imprisonment",
+    data: {
+      items: ["Compendium.dnd5e.spells.ZVnL9L8v1KC9TBF4"],
+    },
+  },
+  incendiarycloud: {
+    name: "Incendiary Cloud",
+    data: {
+      items: ["Compendium.dnd5e.spells.pV04y1iXoWiom6bp"],
+    },
+  },
+  inflictwounds: {
+    name: "Inflict Wounds",
+    data: {
+      items: ["Compendium.dnd5e.spells.ksaaTxIbKx2sJfia"],
+    },
+  },
+  insectplague: {
+    name: "Insect Plague",
+    data: {
+      items: ["Compendium.dnd5e.spells.OVikYmSdHliAG2YD"],
+    },
+  },
+  instantsummons: {
+    name: "Instant Summons",
+    data: {
+      items: ["Compendium.dnd5e.spells.SgrEKiC6dAtvy6Pz"],
+    },
+  },
+  invisibility: {
+    name: "Invisibility",
+    data: {
+      items: ["Compendium.dnd5e.spells.1N8dDMMgZ1h1YJ3B"],
+    },
+  },
+  irresistibledance: {
+    name: "Irresistible Dance",
+    data: {
+      items: ["Compendium.dnd5e.spells.TfRzwEgBHHkCc6Ql"],
+    },
+  },
+  jump: {
+    name: "Jump",
+    data: {
+      items: ["Compendium.dnd5e.spells.ZrTc23tToJ0JpH2h"],
+    },
+  },
+  knock: {
+    name: "Knock",
+    data: {
+      items: ["Compendium.dnd5e.spells.1nhIxh0DsJsntCfj"],
+    },
+  },
+  legendlore: {
+    name: "Legend Lore",
+    data: {
+      items: ["Compendium.dnd5e.spells.W4Qx5z0id6da0vqg"],
+    },
+  },
+  lesserrestoration: {
+    name: "Lesser Restoration",
+    data: {
+      items: ["Compendium.dnd5e.spells.F0GsG0SJzsIOacwV"],
+    },
+  },
+  levitate: {
+    name: "Levitate",
+    data: {
+      items: ["Compendium.dnd5e.spells.MRxldJd6C4bsBo3O"],
+    },
+  },
+  light: {
+    name: "Light",
+    data: {
+      items: ["Compendium.dnd5e.spells.Bnn9Nzajixvow9xi"],
+    },
+  },
+  lightningbolt: {
+    name: "Lightning Bolt",
+    data: {
+      items: ["Compendium.dnd5e.spells.IyikgTEOTv701jgQ"],
+    },
+  },
+  locateanimalsorplants: {
+    name: "Locate Animals or Plants",
+    data: {
+      items: ["Compendium.dnd5e.spells.Iv2qqSAT7OkXKPFx"],
+    },
+  },
+  locatecreature: {
+    name: "Locate Creature",
+    data: {
+      items: ["Compendium.dnd5e.spells.gXtzz9t1DTzJeLr4"],
+    },
+  },
+  locateobject: {
+    name: "Locate Object",
+    data: {
+      items: ["Compendium.dnd5e.spells.SleYkHovQ8NagmeV"],
+    },
+  },
+  longstrider: {
+    name: "Longstrider",
+    data: {
+      items: ["Compendium.dnd5e.spells.B0pnIcc52O6G8hi8"],
+    },
+  },
+  magearmor: {
+    name: "Mage Armor",
+    data: {
+      items: ["Compendium.dnd5e.spells.CKZTpZlxj7hjjo2H"],
+    },
+  },
+  magehand: {
+    name: "Mage Hand",
+    data: {
+      items: ["Compendium.dnd5e.spells.Utk1OQRwYkMkFRD3"],
+    },
+  },
+  magiccircle: {
+    name: "Magic Circle",
+    data: {
+      items: ["Compendium.dnd5e.spells.y8A4HfTwd93ypdEz"],
+    },
+  },
+  magicjar: {
+    name: "Magic Jar",
+    data: {
+      items: ["Compendium.dnd5e.spells.ej6wyY4G1gOcb1U6"],
+    },
+  },
+  magicmissile: {
+    name: "Magic Missile",
+    data: {
+      items: ["Compendium.dnd5e.spells.41JIhpDyM9Anm7cs"],
+    },
+  },
+  magicmouth: {
+    name: "Magic Mouth",
+    data: {
+      items: ["Compendium.dnd5e.spells.7v06rdmUakoTk1LQ"],
+    },
+  },
+  magicweapon: {
+    name: "Magic Weapon",
+    data: {
+      items: ["Compendium.dnd5e.spells.Sgjrf8qqv97CCWM4"],
+    },
+  },
+  magnificentmansion: {
+    name: "Magnificent Mansion",
+    data: {
+      items: ["Compendium.dnd5e.spells.pn4SnsFDvYDiE6rC"],
+    },
+  },
+  majorimage: {
+    name: "Major Image",
+    data: {
+      items: ["Compendium.dnd5e.spells.nslx2nT3p4lNkmdp"],
+    },
+  },
+  masscurewounds: {
+    name: "Mass Cure Wounds",
+    data: {
+      items: ["Compendium.dnd5e.spells.Pyzmm8R7rVsNAPsd"],
+    },
+  },
+  massheal: {
+    name: "Mass Heal",
+    data: {
+      items: ["Compendium.dnd5e.spells.Y6oItIuhOJZ0i0FC"],
+    },
+  },
+  masshealingword: {
+    name: "Mass Healing Word",
+    data: {
+      items: ["Compendium.dnd5e.spells.34ddoYIrnOZ2GFYi"],
+    },
+  },
+  masssuggestion: {
+    name: "Mass Suggestion",
+    data: {
+      items: ["Compendium.dnd5e.spells.5OGFdJw35QXp6mh6"],
+    },
+  },
+  maze: {
+    name: "Maze",
+    data: {
+      items: ["Compendium.dnd5e.spells.clwv2PWOcT822hlr"],
+    },
+  },
+  meldintostone: {
+    name: "Meld into Stone",
+    data: {
+      items: ["Compendium.dnd5e.spells.64uo4fHriHLjRUrX"],
+    },
+  },
+  mending: {
+    name: "Mending",
+    data: {
+      items: ["Compendium.dnd5e.spells.kjmjY0zlE6IEiQVL"],
+    },
+  },
+  message: {
+    name: "Message",
+    data: {
+      items: ["Compendium.dnd5e.spells.icZokbgV1jIMpNCv"],
+    },
+  },
+  meteorswarm: {
+    name: "Meteor Swarm",
+    data: {
+      items: ["Compendium.dnd5e.spells.mF52ldF79Cr7wfQo"],
+    },
+  },
+  mindblank: {
+    name: "Mind Blank",
+    data: {
+      items: ["Compendium.dnd5e.spells.bllEWfm9xfEKynhv"],
+    },
+  },
+  minorillusion: {
+    name: "Minor Illusion",
+    data: {
+      items: ["Compendium.dnd5e.spells.oIzA2MEHwxhtQneU"],
+    },
+  },
+  miragearcane: {
+    name: "Mirage Arcane",
+    data: {
+      items: ["Compendium.dnd5e.spells.f38w5rd9SgdmWc6F"],
+    },
+  },
+  mirrorimage: {
+    name: "Mirror Image",
+    data: {
+      items: ["Compendium.dnd5e.spells.X4c8xCkmF8U9HUMz"],
+    },
+  },
+  mislead: {
+    name: "Mislead",
+    data: {
+      items: ["Compendium.dnd5e.spells.MBMaQLwoy05qzMJ3"],
+    },
+  },
+  mistystep: {
+    name: "Misty Step",
+    data: {
+      items: ["Compendium.dnd5e.spells.wqfAVANuQonNBgnL"],
+    },
+  },
+  modifymemory: {
+    name: "Modify Memory",
+    data: {
+      items: ["Compendium.dnd5e.spells.r3243JU4AyQJyfX4"],
+    },
+  },
+  moonbeam: {
+    name: "Moonbeam",
+    data: {
+      items: ["Compendium.dnd5e.spells.bV3yun6MIuFj71Er"],
+    },
+  },
+  moveearth: {
+    name: "Move Earth",
+    data: {
+      items: ["Compendium.dnd5e.spells.yI0XWIgI0IGGsR3R"],
+    },
+  },
+  nondetection: {
+    name: "Nondetection",
+    data: {
+      items: ["Compendium.dnd5e.spells.aU62xVUBYkAQWIHv"],
+    },
+  },
+  passwithouttrace: {
+    name: "Pass without Trace",
+    data: {
+      items: ["Compendium.dnd5e.spells.pRMvmknwLf2tdMTj"],
+    },
+  },
+  passwall: {
+    name: "Passwall",
+    data: {
+      items: ["Compendium.dnd5e.spells.d9MwcXi7Il3HROXd"],
+    },
+  },
+  phantasmalkiller: {
+    name: "Phantasmal Killer",
+    data: {
+      items: ["Compendium.dnd5e.spells.BYNvBJzHcF5VJhXw"],
+    },
+  },
+  phantomsteed: {
+    name: "Phantom Steed",
+    data: {
+      items: ["Compendium.dnd5e.spells.wpx42mtoZ5BmXRs1"],
+    },
+  },
+  planarally: {
+    name: "Planar Ally",
+    data: {
+      items: ["Compendium.dnd5e.spells.fkREcytuZ8sngWtC"],
+    },
+  },
+  planarbinding: {
+    name: "Planar Binding",
+    data: {
+      items: ["Compendium.dnd5e.spells.42O2aNBW7vK90gTL"],
+    },
+  },
+  planeshift: {
+    name: "Plane Shift",
+    data: {
+      items: ["Compendium.dnd5e.spells.J6Jpw5XzB5aTeqnz"],
+    },
+  },
+  plantgrowth: {
+    name: "Plant Growth",
+    data: {
+      items: ["Compendium.dnd5e.spells.YWtwzp6ZnQJMEmVW"],
+    },
+  },
+  poisonspray: {
+    name: "Poison Spray",
+    data: {
+      items: ["Compendium.dnd5e.spells.g2u9PYfqWQAyg9OI"],
+    },
+  },
+  polymorph: {
+    name: "Polymorph",
+    data: {
+      items: ["Compendium.dnd5e.spells.04nMsTWkIFvkbXlY"],
+    },
+  },
+  powerwordkill: {
+    name: "Power Word Kill",
+    data: {
+      items: ["Compendium.dnd5e.spells.dmvaMLFWFtv0qx0S"],
+    },
+  },
+  powerwordstun: {
+    name: "Power Word Stun",
+    data: {
+      items: ["Compendium.dnd5e.spells.35j2QIMmIk6aEdxj"],
+    },
+  },
+  prayerofhealing: {
+    name: "Prayer of Healing",
+    data: {
+      items: ["Compendium.dnd5e.spells.MOEmz9N0j0QPkKEE"],
+    },
+  },
+  prestidigitation: {
+    name: "Prestidigitation",
+    data: {
+      items: ["Compendium.dnd5e.spells.udsLtG0BugXHR2JQ"],
+    },
+  },
+  prismaticspray: {
+    name: "Prismatic Spray",
+    data: {
+      items: ["Compendium.dnd5e.spells.eGMhwmuleAM46C6L"],
+    },
+  },
+  prismaticwall: {
+    name: "Prismatic Wall",
+    data: {
+      items: ["Compendium.dnd5e.spells.jmfu8zj4zjjzUbeh"],
+    },
+  },
+  privatesanctum: {
+    name: "Private Sanctum",
+    data: {
+      items: ["Compendium.dnd5e.spells.NJgxf7pmSsBArIG7"],
+    },
+  },
+  produceflame: {
+    name: "Produce Flame",
+    data: {
+      items: ["Compendium.dnd5e.spells.eCPQuQkIabFKTl9u"],
+    },
+  },
+  programmedillusion: {
+    name: "Programmed Illusion",
+    data: {
+      items: ["Compendium.dnd5e.spells.bA2sk9eMKBeY7EPD"],
+    },
+  },
+  projectimage: {
+    name: "Project Image",
+    data: {
+      items: ["Compendium.dnd5e.spells.ePhRKHXRE7l1sEoQ"],
+    },
+  },
+  protectionfromenergy: {
+    name: "Protection from Energy",
+    data: {
+      items: ["Compendium.dnd5e.spells.j8NtLXOOJ3GAKF8I"],
+    },
+  },
+  protectionfromevilandgood: {
+    name: "Protection from Evil and Good",
+    data: {
+      items: ["Compendium.dnd5e.spells.xmDBqZhRVrtLP8h2"],
+    },
+  },
+  protectionfrompoison: {
+    name: "Protection from Poison",
+    data: {
+      items: ["Compendium.dnd5e.spells.MAxM77CDUu8dgIRQ"],
+    },
+  },
+  purifyfoodanddrink: {
+    name: "Purify Food and Drink",
+    data: {
+      items: ["Compendium.dnd5e.spells.Kn7K5PtYUJAKZTTp"],
+    },
+  },
+  raisedead: {
+    name: "Raise Dead",
+    data: {
+      items: ["Compendium.dnd5e.spells.AGFMPAmuzwWO6Dfz"],
+    },
+  },
+  rayofenfeeblement: {
+    name: "Ray of Enfeeblement",
+    data: {
+      items: ["Compendium.dnd5e.spells.ODhLKBxLnvvLOnw1"],
+    },
+  },
+  rayoffrost: {
+    name: "Ray of Frost",
+    data: {
+      items: ["Compendium.dnd5e.spells.ctW81uiX56xZR2c5"],
+    },
+  },
+  regenerate: {
+    name: "Regenerate",
+    data: {
+      items: ["Compendium.dnd5e.spells.9kGrFXnLiRg3Xnbo"],
+    },
+  },
+  reincarnate: {
+    name: "Reincarnate",
+    data: {
+      items: ["Compendium.dnd5e.spells.zMEo5DKK8uxsuWnq"],
+    },
+  },
+  removecurse: {
+    name: "Remove Curse",
+    data: {
+      items: ["Compendium.dnd5e.spells.XZhdgVK3cLoxNCQl"],
+    },
+  },
+  resilientsphere: {
+    name: "Resilient Sphere",
+    data: {
+      items: ["Compendium.dnd5e.spells.1ADstb0Xec6HHRcU"],
+    },
+  },
+  resistance: {
+    name: "Resistance",
+    data: {
+      items: ["Compendium.dnd5e.spells.dl8YwvMboBqX2OC4"],
+    },
+  },
+  resurrection: {
+    name: "Resurrection",
+    data: {
+      items: ["Compendium.dnd5e.spells.jhhT9PsHy5A7EojO"],
+    },
+  },
+  reversegravity: {
+    name: "Reverse Gravity",
+    data: {
+      items: ["Compendium.dnd5e.spells.ERCv7yuRkQ0YjGx6"],
+    },
+  },
+  revivify: {
+    name: "Revivify",
+    data: {
+      items: ["Compendium.dnd5e.spells.LmRHHMtplpxr9fX6"],
+    },
+  },
+  ropetrick: {
+    name: "Rope Trick",
+    data: {
+      items: ["Compendium.dnd5e.spells.ap4dmtshjEbwU3Ts"],
+    },
+  },
+  sacredflame: {
+    name: "Sacred Flame",
+    data: {
+      items: ["Compendium.dnd5e.spells.n9pJzTDsAwQxJVRl"],
+    },
+  },
+  sanctuary: {
+    name: "Sanctuary",
+    data: {
+      items: ["Compendium.dnd5e.spells.gvdA9nPuWLck4tBl"],
+    },
+  },
+  scorchingray: {
+    name: "Scorching Ray",
+    data: {
+      items: ["Compendium.dnd5e.spells.7u2obDvuvtZBkTfq"],
+    },
+  },
+  scrying: {
+    name: "Scrying",
+    data: {
+      items: ["Compendium.dnd5e.spells.fVbCxFRaORalHB20"],
+    },
+  },
+  secretchest: {
+    name: "Secret Chest",
+    data: {
+      items: ["Compendium.dnd5e.spells.8sgwRh8NUNkn9Vi0"],
+    },
+  },
+  seeinvisibility: {
+    name: "See Invisibility",
+    data: {
+      items: ["Compendium.dnd5e.spells.DQzlB5Y3k791W5bH"],
+    },
+  },
+  seeming: {
+    name: "Seeming",
+    data: {
+      items: ["Compendium.dnd5e.spells.mbFw57uyfLkyiw5k"],
+    },
+  },
+  sending: {
+    name: "Sending",
+    data: {
+      items: ["Compendium.dnd5e.spells.GtGjNjPBgUHxGYAD"],
+    },
+  },
+  sequester: {
+    name: "Sequester",
+    data: {
+      items: ["Compendium.dnd5e.spells.wvLbtemkH8gyBpdc"],
+    },
+  },
+  shapechange: {
+    name: "Shapechange",
+    data: {
+      items: ["Compendium.dnd5e.spells.N2UEFq8X5LRsLcOZ"],
+    },
+  },
+  shatter: {
+    name: "Shatter",
+    data: {
+      items: ["Compendium.dnd5e.spells.wJKpSvSTbSkTjqyb"],
+    },
+  },
+  shield: {
+    name: "Shield",
+    data: {
+      items: ["Compendium.dnd5e.spells.z1mx84ONwkXKUZd7"],
+    },
+  },
+  shieldoffaith: {
+    name: "Shield of Faith",
+    data: {
+      items: ["Compendium.dnd5e.spells.jZ6JNykRtdQ90MOo"],
+    },
+  },
+  shillelagh: {
+    name: "Shillelagh",
+    data: {
+      items: ["Compendium.dnd5e.spells.VzgFzcmocr1X1cp4"],
+    },
+  },
+  shockinggrasp: {
+    name: "Shocking Grasp",
+    data: {
+      items: ["Compendium.dnd5e.spells.XvbiNhNqXXIFisIy"],
+    },
+  },
+  silence: {
+    name: "Silence",
+    data: {
+      items: ["Compendium.dnd5e.spells.5VhqFROQYjr1P9lp"],
+    },
+  },
+  silentimage: {
+    name: "Silent Image",
+    data: {
+      items: ["Compendium.dnd5e.spells.BrBZdCCrJRIVg7YX"],
+    },
+  },
+  simulacrum: {
+    name: "Simulacrum",
+    data: {
+      items: ["Compendium.dnd5e.spells.jccbeBIfLrqEZnDP"],
+    },
+  },
+  sleep: {
+    name: "Sleep",
+    data: {
+      items: ["Compendium.dnd5e.spells.KhwiSi9fwVfUPtku"],
+    },
+  },
+  sleetstorm: {
+    name: "Sleet Storm",
+    data: {
+      items: ["Compendium.dnd5e.spells.dhqBY4TvVjxVmOZd"],
+    },
+  },
+  slow: {
+    name: "Slow",
+    data: {
+      items: ["Compendium.dnd5e.spells.yqUDoxk4x0NWG5Bz"],
+    },
+  },
+  sparethedying: {
+    name: "Spare the Dying",
+    data: {
+      items: ["Compendium.dnd5e.spells.8zT7njvqbpXs4Cel"],
+    },
+  },
+  speakwithanimals: {
+    name: "Speak with Animals",
+    data: {
+      items: ["Compendium.dnd5e.spells.aL1F8fvYLtNzUbKu"],
+    },
+  },
+  speakwithdead: {
+    name: "Speak with Dead",
+    data: {
+      items: ["Compendium.dnd5e.spells.I2LUSF5ogc7Bj62e"],
+    },
+  },
+  speakwithplants: {
+    name: "Speak with Plants",
+    data: {
+      items: ["Compendium.dnd5e.spells.2VXGS206tuChoeXy"],
+    },
+  },
+  spiderclimb: {
+    name: "Spider Climb",
+    data: {
+      items: ["Compendium.dnd5e.spells.KJRVzeMQXPj8Gtyx"],
+    },
+  },
+  spikegrowth: {
+    name: "Spike Growth",
+    data: {
+      items: ["Compendium.dnd5e.spells.9gYGkrL6qFTsE6fw"],
+    },
+  },
+  spiritguardians: {
+    name: "Spirit Guardians",
+    data: {
+      items: ["Compendium.dnd5e.spells.uCud2s4TjMfjiXUb"],
+    },
+  },
+  spiritualweapon: {
+    name: "Spiritual Weapon",
+    data: {
+      items: ["Compendium.dnd5e.spells.JbxsYXxSOTZbf9I0"],
+    },
+  },
+  stinkingcloud: {
+    name: "Stinking Cloud",
+    data: {
+      items: ["Compendium.dnd5e.spells.TwlD4PLcltv7Xh7j"],
+    },
+  },
+  stoneshape: {
+    name: "Stone Shape",
+    data: {
+      items: ["Compendium.dnd5e.spells.QvGcdRUSNRKEQJlK"],
+    },
+  },
+  stoneskin: {
+    name: "Stoneskin",
+    data: {
+      items: ["Compendium.dnd5e.spells.ReMbjfeOKoSj3O79"],
+    },
+  },
+  stormofvengeance: {
+    name: "Storm of Vengeance",
+    data: {
+      items: ["Compendium.dnd5e.spells.7KjExw0kmuqERa7C"],
+    },
+  },
+  suggestion: {
+    name: "Suggestion",
+    data: {
+      items: ["Compendium.dnd5e.spells.zMAWdyc8UVb37BK4"],
+    },
+  },
+  sunbeam: {
+    name: "Sunbeam",
+    data: {
+      items: ["Compendium.dnd5e.spells.2RC0EyvBLPH88PZF"],
+    },
+  },
+  sunburst: {
+    name: "Sunburst",
+    data: {
+      items: ["Compendium.dnd5e.spells.hzK7FQya0BDjSmLE"],
+    },
+  },
+  symbol: {
+    name: "Symbol",
+    data: {
+      items: ["Compendium.dnd5e.spells.B2kbmgbA2WQR00kx"],
+    },
+  },
+  telekinesis: {
+    name: "Telekinesis",
+    data: {
+      items: ["Compendium.dnd5e.spells.HQfd7jJyULIoGxrZ"],
+    },
+  },
+  telepathicbond: {
+    name: "Telepathic Bond",
+    data: {
+      items: ["Compendium.dnd5e.spells.uAwtVZkiSTyP6ORB"],
+    },
+  },
+  teleport: {
+    name: "Teleport",
+    data: {
+      items: ["Compendium.dnd5e.spells.L4J89JXqbKs6puEV"],
+    },
+  },
+  teleportationcircle: {
+    name: "Teleportation Circle",
+    data: {
+      items: ["Compendium.dnd5e.spells.8aWtP5hcrmcEesBW"],
+    },
+  },
+  thaumaturgy: {
+    name: "Thaumaturgy",
+    data: {
+      items: ["Compendium.dnd5e.spells.MUO1uYN7JR1hm4dR"],
+    },
+  },
+  thunderwave: {
+    name: "Thunderwave",
+    data: {
+      items: ["Compendium.dnd5e.spells.WTbOQBsarsL1LuXJ"],
+    },
+  },
+  timestop: {
+    name: "Time Stop",
+    data: {
+      items: ["Compendium.dnd5e.spells.JYuRBwxpoFhXduvD"],
+    },
+  },
+  tinyhut: {
+    name: "Tiny Hut",
+    data: {
+      items: ["Compendium.dnd5e.spells.NXWWWgHtWb7Nv21F"],
+    },
+  },
+  tongues: {
+    name: "Tongues",
+    data: {
+      items: ["Compendium.dnd5e.spells.gopnZvS0c2jD5FP8"],
+    },
+  },
+  transportviaplants: {
+    name: "Transport via Plants",
+    data: {
+      items: ["Compendium.dnd5e.spells.s7nXgot5gGZVcMrv"],
+    },
+  },
+  treestride: {
+    name: "Tree Stride",
+    data: {
+      items: ["Compendium.dnd5e.spells.DUBgwHPakcLDkB6W"],
+    },
+  },
+  truepolymorph: {
+    name: "True Polymorph",
+    data: {
+      items: ["Compendium.dnd5e.spells.QbQZKoXOgHWN06aa"],
+    },
+  },
+  trueresurrection: {
+    name: "True Resurrection",
+    data: {
+      items: ["Compendium.dnd5e.spells.qLeEXZDbW5y4bmLY"],
+    },
+  },
+  trueseeing: {
+    name: "True Seeing",
+    data: {
+      items: ["Compendium.dnd5e.spells.XzkJpE6XpZfKjODD"],
+    },
+  },
+  truestrike: {
+    name: "True Strike",
+    data: {
+      items: ["Compendium.dnd5e.spells.mGGlcLdggHwcL7MG"],
+    },
+  },
+  unseenservant: {
+    name: "Unseen Servant",
+    data: {
+      items: ["Compendium.dnd5e.spells.ccduLIvutyNqvkgv"],
+    },
+  },
+  vampirictouch: {
+    name: "Vampiric Touch",
+    data: {
+      items: ["Compendium.dnd5e.spells.UfHQhA54M4323gVO"],
+    },
+  },
+  viciousmockery: {
+    name: "Vicious Mockery",
+    data: {
+      items: ["Compendium.dnd5e.spells.cdrYKaFi98YWaBMw"],
+    },
+  },
+  walloffire: {
+    name: "Wall of Fire",
+    data: {
+      items: ["Compendium.dnd5e.spells.X3DrXgxjwI2dvkD6"],
+    },
+  },
+  wallofforce: {
+    name: "Wall of Force",
+    data: {
+      items: ["Compendium.dnd5e.spells.o9ZCvuD2B1OTcubb"],
+    },
+  },
+  wallofice: {
+    name: "Wall of Ice",
+    data: {
+      items: ["Compendium.dnd5e.spells.fzZnVKLmBMo2f5up"],
+    },
+  },
+  wallofstone: {
+    name: "Wall of Stone",
+    data: {
+      items: ["Compendium.dnd5e.spells.NmoRmM1mhuM3pqnY"],
+    },
+  },
+  wallofthorns: {
+    name: "Wall of Thorns",
+    data: {
+      items: ["Compendium.dnd5e.spells.AQsBc94ES7W7s7iG"],
+    },
+  },
+  wardingbond: {
+    name: "Warding Bond",
+    data: {
+      items: ["Compendium.dnd5e.spells.JVhKeanAXZH62DrF"],
+    },
+  },
+  waterbreathing: {
+    name: "Water Breathing",
+    data: {
+      items: ["Compendium.dnd5e.spells.13uVuBQP6VaiSPvC"],
+    },
+  },
+  waterwalk: {
+    name: "Water Walk",
+    data: {
+      items: ["Compendium.dnd5e.spells.YBda6nLKjxdT1LbS"],
+    },
+  },
+  web: {
+    name: "Web",
+    data: {
+      items: ["Compendium.dnd5e.spells.UJJu9c2UvCzVljiP"],
+    },
+  },
+  weird: {
+    name: "Weird",
+    data: {
+      items: ["Compendium.dnd5e.spells.Wl2vtJ4hCt2tpWfR"],
+    },
+  },
+  windwalk: {
+    name: "Wind Walk",
+    data: {
+      items: ["Compendium.dnd5e.spells.8PJAsHmbu6UgDHC0"],
+    },
+  },
+  windwall: {
+    name: "Wind Wall",
+    data: {
+      items: ["Compendium.dnd5e.spells.ew6GA8dJy2spQmFW"],
+    },
+  },
+  wish: {
+    name: "Wish",
+    data: {
+      items: ["Compendium.dnd5e.spells.3okM6Gn63zzEULkz"],
+    },
+  },
+  wordofrecall: {
+    name: "Word of Recall",
+    data: {
+      items: ["Compendium.dnd5e.spells.76C0FdcxlU8F9Rl2"],
+    },
+  },
+  zoneoftruth: {
+    name: "Zone of Truth",
+    data: {
+      items: ["Compendium.dnd5e.spells.CylBa7jR8DSbo8Z3"],
+    },
+  },
+};
+
+const classSpells = {
+  barbarian: {
+    0: [],
+    1: [],
+    2: [],
+    3: [],
+    4: [],
+    5: [],
+    6: [],
+    7: [],
+    8: [],
+    9: [],
+  },
+  bard: {
+    0: [
+      "dancinglights",
+      "light",
+      "magehand",
+      "mending",
+      "message",
+      "minorillusion",
+      "prestidigitation",
+      "truestrike",
+      "viciousmockery",
+    ],
+    1: [
+      "animalfriendship",
+      "bane",
+      "charmperson",
+      "comprehendlanguages",
+      "curewounds",
+      "detectmagic",
+      "disguiseself",
+      "featherfall",
+      "healingword",
+      "heroism",
+      "hideouslaughter",
+      "identify",
+      "illusoryscript",
+      "longstrider",
+      "silentimage",
+      "sleep",
+      "speakwithanimals",
+      "thunderwave",
+      "unseenservant",
+    ],
+    2: [
+      "animalmessenger",
+      "blindness/deafness",
+      "calmemotions",
+      "detectthoughts",
+      "enhanceability",
+      "enthrall",
+      "heatmetal",
+      "holdperson",
+      "invisibility",
+      "knock",
+      "lesserrestoration",
+      "locateanimalsorplants",
+      "locateobject",
+      "magicmouth",
+      "seeinvisibility",
+      "shatter",
+      "silence",
+      "suggestion",
+      "zoneoftruth",
+    ],
+    3: [
+      "bestowcurse",
+      "clairvoyance",
+      "dispelmagic",
+      "fear",
+      "glyphofwarding",
+      "hypnoticpattern",
+      "majorimage",
+      "nondetection",
+      "plantgrowth",
+      "sending",
+      "speakwithdead",
+      "speakwithplants",
+      "stinkingcloud",
+      "tinyhut",
+      "tongues",
+    ],
+    4: [
+      "compulsion",
+      "confusion",
+      "dimensiondoor",
+      "freedomofmovement",
+      "greaterinvisibility",
+      "hallucinatoryterrain",
+      "locatecreature",
+      "polymorph",
+    ],
+    5: [
+      "animateobjects",
+      "awaken",
+      "dominateperson",
+      "dream",
+      "geas",
+      "greaterrestoration",
+      "holdmonster",
+      "legendlore",
+      "masscurewounds",
+      "mislead",
+      "modifymemory",
+      "planarbinding",
+      "raisedead",
+      "scrying",
+      "seeming",
+      "teleportationcircle",
+    ],
+    6: [
+      "eyebite",
+      "findthepath",
+      "guardsandwards",
+      "irresistibledance",
+      "masssuggestion",
+      "programmedillusion",
+      "trueseeing",
+    ],
+    7: [
+      "arcanesword",
+      "etherealness",
+      "forcecage",
+      "magnificentmansion",
+      "miragearcane",
+      "projectimage",
+      "regenerate",
+      "resurrection",
+      "symbol",
+      "teleport",
+    ],
+    8: ["dominatemonster", "feeblemind", "glibness", "mindblank", "powerwordstun"],
+    9: ["foresight", "powerwordkill", "truepolymorph"],
+  },
+  cleric: {
+    0: [
+      "guidance",
+      "light",
+      "mending",
+      "resistance",
+      "sacredflame",
+      "sparethedying",
+      "thaumaturgy",
+    ],
+    1: [
+      "animalfriendship",
+      "bane",
+      "bless",
+      "command",
+      "createordestroywater",
+      "curewounds",
+      "detectevilandgood",
+      "detectmagic",
+      "detectpoisonanddisease",
+      "guidingbolt",
+      "healingword",
+      "inflictwounds",
+      "protectionfromevilandgood",
+      "purifyfoodanddrink",
+      "sanctuary",
+      "shieldoffaith",
+    ],
+    2: [
+      "aid",
+      "augury",
+      "blindness/deafness",
+      "calmemotions",
+      "continualflame",
+      "enhanceability",
+      "findtraps",
+      "gentlerepose",
+      "holdperson",
+      "lesserrestoration",
+      "locateobject",
+      "prayerofhealing",
+      "protectionfrompoison",
+      "silence",
+      "spiritualweapon",
+      "wardingbond",
+      "zoneoftruth",
+    ],
+    3: [
+      "animatedead",
+      "beaconofhope",
+      "bestowcurse",
+      "clairvoyance",
+      "createfoodandwater",
+      "daylight",
+      "dispelmagic",
+      "glyphofwarding",
+      "magiccircle",
+      "masshealingword",
+      "meldintostone",
+      "protectionfromenergy",
+      "removecurse",
+      "revivify",
+      "sending",
+      "speakwithdead",
+      "spiritguardians",
+      "tongues",
+      "waterwalk",
+    ],
+    4: [
+      "arcaneeye",
+      "banishment",
+      "controlwater",
+      "deathward",
+      "freedomofmovement",
+      "guardianoffaith",
+      "locatecreature",
+      "stoneshape",
+    ],
+    5: [
+      "commune",
+      "contagion",
+      "dispelevilandgood",
+      "flamestrike",
+      "geas",
+      "greaterrestoration",
+      "hallow",
+      "insectplague",
+      "legendlore",
+      "masscurewounds",
+      "planarbinding",
+      "raisedead",
+      "scrying",
+    ],
+    6: [
+      "bladebarrier",
+      "createundead",
+      "findthepath",
+      "forbiddance",
+      "harm",
+      "heal",
+      "heroes'feast",
+      "planarally",
+      "trueseeing",
+      "wordofrecall",
+    ],
+    7: [
+      "conjurecelestial",
+      "divineword",
+      "etherealness",
+      "firestorm",
+      "planeshift",
+      "regenerate",
+      "resurrection",
+      "symbol",
+    ],
+    8: ["antimagicfield", "controlweather", "earthquake", "holyaura"],
+    9: ["astralprojection", "gate", "massheal", "trueresurrection"],
+  },
+  druid: {
+    0: ["druidcraft", "guidance", "mending", "produceflame", "resistance", "shillelagh"],
+    1: [
+      "animalfriendship",
+      "charmperson",
+      "createordestroywater",
+      "curewounds",
+      "detectmagic",
+      "detectpoisonanddisease",
+      "entangle",
+      "faeriefire",
+      "fogcloud",
+      "goodberry",
+      "healingword",
+      "jump",
+      "longstrider",
+      "purifyfoodanddrink",
+      "speakwithanimals",
+      "thunderwave",
+    ],
+    2: [
+      "animalmessenger",
+      "barkskin",
+      "darkvision",
+      "enhanceability",
+      "findtraps",
+      "flameblade",
+      "flamingsphere",
+      "gustofwind",
+      "heatmetal",
+      "holdperson",
+      "lesserrestoration",
+      "locateanimalsorplants",
+      "locateobject",
+      "moonbeam",
+      "passwithouttrace",
+      "protectionfrompoison",
+      "spikegrowth",
+    ],
+    3: [
+      "calllightning",
+      "conjureanimals",
+      "createfoodandwater",
+      "daylight",
+      "dispelmagic",
+      "plantgrowth",
+      "protectionfromenergy",
+      "sleetstorm",
+      "speakwithplants",
+      "waterbreathing",
+      "waterwalk",
+      "windwall",
+    ],
+    4: [
+      "blight",
+      "confusion",
+      "conjureminorelementals",
+      "conjurewoodlandbeings",
+      "controlwater",
+      "divination",
+      "dominatebeast",
+      "freedomofmovement",
+      "giantinsect",
+      "hallucinatoryterrain",
+      "icestorm",
+      "locatecreature",
+      "polymorph",
+      "stoneshape",
+      "stoneskin",
+      "walloffire",
+    ],
+    5: [
+      "antilifeshell",
+      "awaken",
+      "communewithnature",
+      "conjureelemental",
+      "contagion",
+      "geas",
+      "greaterrestoration",
+      "insectplague",
+      "masscurewounds",
+      "planarbinding",
+      "reincarnate",
+      "scrying",
+      "treestride",
+      "wallofstone",
+    ],
+    6: [
+      "conjurefey",
+      "heal",
+      "heroes'feast",
+      "moveearth",
+      "sunbeam",
+      "transportviaplants",
+      "wallofthorns",
+      "windwalk",
+    ],
+    7: ["firestorm", "miragearcane", "planeshift", "regenerate", "reversegravity"],
+    8: [
+      "animalshapes",
+      "antipathy/sympathy",
+      "controlweather",
+      "earthquake",
+      "feeblemind",
+      "sunburst",
+    ],
+    9: ["foresight", "shapechange", "stormofvengeance", "trueresurrection"],
+  },
+  fighter: {
+    0: [],
+    1: [],
+    2: [],
+    3: [],
+    4: [],
+    5: [],
+    6: [],
+    7: [],
+    8: [],
+    9: [],
+  },
+  monk: {
+    0: [],
+    1: [],
+    2: [],
+    3: [],
+    4: [],
+    5: [],
+    6: [],
+    7: [],
+    8: [],
+    9: [],
+  },
+  paladin: {
+    0: [],
+    1: [
+      "bless",
+      "command",
+      "curewounds",
+      "detectevilandgood",
+      "detectmagic",
+      "detectpoisonanddisease",
+      "divinefavor",
+      "heroism",
+      "hunter'smark",
+      "protectionfromevilandgood",
+      "purifyfoodanddrink",
+      "shieldoffaith",
+    ],
+    2: [
+      "aid",
+      "brandingsmite",
+      "findsteed",
+      "lesserrestoration",
+      "locateobject",
+      "magicweapon",
+      "protectionfrompoison",
+      "zoneoftruth",
+    ],
+    3: ["createfoodandwater", "daylight", "dispelmagic", "magiccircle", "removecurse", "revivify"],
+    4: ["banishment", "deathward", "guardianoffaith", "locatecreature"],
+    5: ["dispelevilandgood", "geas", "raisedead"],
+    6: [],
+    7: [],
+    8: [],
+    9: [],
+  },
+  ranger: {
+    0: [],
+    1: [
+      "alarm",
+      "animalfriendship",
+      "curewounds",
+      "detectmagic",
+      "detectpoisonanddisease",
+      "fogcloud",
+      "goodberry",
+      "hunter'smark",
+      "jump",
+      "longstrider",
+      "speakwithanimals",
+    ],
+    2: [
+      "animalmessenger",
+      "barkskin",
+      "darkvision",
+      "findtraps",
+      "lesserrestoration",
+      "locateanimalsorplants",
+      "locateobject",
+      "passwithouttrace",
+      "protectionfrompoison",
+      "silence",
+      "spikegrowth",
+    ],
+    3: [
+      "conjureanimals",
+      "daylight",
+      "nondetection",
+      "plantgrowth",
+      "protectionfromenergy",
+      "speakwithplants",
+      "waterbreathing",
+      "waterwalk",
+      "windwall",
+    ],
+    4: ["conjurewoodlandbeings", "freedomofmovement", "locatecreature", "stoneskin"],
+    5: ["communewithnature", "treestride"],
+    6: [],
+    7: [],
+    8: [],
+    9: [],
+  },
+  rogue: {
+    0: [],
+    1: [],
+    2: [],
+    3: [],
+    4: [],
+    5: [],
+    6: [],
+    7: [],
+    8: [],
+    9: [],
+  },
+  sorcerer: {
+    0: [
+      "acidsplash",
+      "chilltouch",
+      "dancinglights",
+      "firebolt",
+      "light",
+      "magehand",
+      "mending",
+      "message",
+      "minorillusion",
+      "poisonspray",
+      "prestidigitation",
+      "rayoffrost",
+      "shockinggrasp",
+      "truestrike",
+    ],
+    1: [
+      "burninghands",
+      "charmperson",
+      "colorspray",
+      "comprehendlanguages",
+      "detectmagic",
+      "disguiseself",
+      "expeditiousretreat",
+      "falselife",
+      "featherfall",
+      "fogcloud",
+      "jump",
+      "magearmor",
+      "magicmissile",
+      "shield",
+      "silentimage",
+      "sleep",
+      "thunderwave",
+    ],
+    2: [
+      "alterself",
+      "blindness/deafness",
+      "blur",
+      "darkness",
+      "darkvision",
+      "detectthoughts",
+      "enhanceability",
+      "enlarge/reduce",
+      "gustofwind",
+      "holdperson",
+      "invisibility",
+      "knock",
+      "levitate",
+      "mirrorimage",
+      "mistystep",
+      "scorchingray",
+      "seeinvisibility",
+      "shatter",
+      "spiderclimb",
+      "suggestion",
+      "web",
+    ],
+    3: [
+      "blink",
+      "clairvoyance",
+      "counterspell",
+      "daylight",
+      "dispelmagic",
+      "fear",
+      "fireball",
+      "fly",
+      "gaseousform",
+      "haste",
+      "hypnoticpattern",
+      "lightningbolt",
+      "majorimage",
+      "protectionfromenergy",
+      "sleetstorm",
+      "slow",
+      "stinkingcloud",
+      "tongues",
+      "waterbreathing",
+      "waterwalk",
+    ],
+    4: [
+      "banishment",
+      "blight",
+      "confusion",
+      "dimensiondoor",
+      "dominatebeast",
+      "greaterinvisibility",
+      "icestorm",
+      "polymorph",
+      "stoneskin",
+      "walloffire",
+    ],
+    5: [
+      "animateobjects",
+      "cloudkill",
+      "coneofcold",
+      "creation",
+      "dominateperson",
+      "holdmonster",
+      "insectplague",
+      "seeming",
+      "telekinesis",
+      "teleportationcircle",
+      "wallofstone",
+    ],
+    6: [
+      "chainlightning",
+      "circleofdeath",
+      "disintegrate",
+      "eyebite",
+      "globeofinvulnerability",
+      "masssuggestion",
+      "moveearth",
+      "sunbeam",
+      "trueseeing",
+    ],
+    7: [
+      "delayedblastfireball",
+      "etherealness",
+      "fingerofdeath",
+      "firestorm",
+      "planeshift",
+      "prismaticspray",
+      "reversegravity",
+      "teleport",
+    ],
+    8: ["dominatemonster", "earthquake", "incendiarycloud", "powerwordstun", "sunburst"],
+    9: ["gate", "meteorswarm", "powerwordkill", "timestop", "wish"],
+  },
+  wizard: {
+    0: [
+      "acidsplash",
+      "chilltouch",
+      "dancinglights",
+      "firebolt",
+      "light",
+      "magehand",
+      "mending",
+      "message",
+      "minorillusion",
+      "poisonspray",
+      "prestidigitation",
+      "rayoffrost",
+      "shockinggrasp",
+      "truestrike",
+    ],
+    1: [
+      "alarm",
+      "burninghands",
+      "charmperson",
+      "colorspray",
+      "comprehendlanguages",
+      "detectmagic",
+      "disguiseself",
+      "expeditiousretreat",
+      "falselife",
+      "featherfall",
+      "findfamiliar",
+      "floatingdisk",
+      "fogcloud",
+      "grease",
+      "hideouslaughter",
+      "identify",
+      "illusoryscript",
+      "jump",
+      "longstrider",
+      "magearmor",
+      "magicmissile",
+      "protectionfromevilandgood",
+      "shield",
+      "silentimage",
+      "sleep",
+      "thunderwave",
+      "unseenservant",
+    ],
+    2: [
+      "acidarrow",
+      "alterself",
+      "arcanelock",
+      "arcanist'smagicaura",
+      "blindness/deafness",
+      "blur",
+      "continualflame",
+      "darkness",
+      "darkvision",
+      "detectthoughts",
+      "enlarge/reduce",
+      "flamingsphere",
+      "gentlerepose",
+      "gustofwind",
+      "holdperson",
+      "invisibility",
+      "knock",
+      "levitate",
+      "locateobject",
+      "magicmouth",
+      "magicweapon",
+      "mirrorimage",
+      "mistystep",
+      "rayofenfeeblement",
+      "ropetrick",
+      "scorchingray",
+      "seeinvisibility",
+      "shatter",
+      "spiderclimb",
+      "suggestion",
+      "web",
+    ],
+    3: [
+      "animatedead",
+      "bestowcurse",
+      "blink",
+      "clairvoyance",
+      "counterspell",
+      "dispelmagic",
+      "fear",
+      "fireball",
+      "fly",
+      "gaseousform",
+      "glyphofwarding",
+      "haste",
+      "hypnoticpattern",
+      "lightningbolt",
+      "magiccircle",
+      "majorimage",
+      "nondetection",
+      "phantomsteed",
+      "protectionfromenergy",
+      "removecurse",
+      "sending",
+      "sleetstorm",
+      "slow",
+      "stinkingcloud",
+      "tinyhut",
+      "tongues",
+      "vampirictouch",
+      "waterbreathing",
+    ],
+    4: [
+      "arcaneeye",
+      "banishment",
+      "blacktentacles",
+      "blight",
+      "confusion",
+      "conjureminorelementals",
+      "controlwater",
+      "dimensiondoor",
+      "fabricate",
+      "faithfulhound",
+      "fireshield",
+      "greaterinvisibility",
+      "hallucinatoryterrain",
+      "icestorm",
+      "locatecreature",
+      "phantasmalkiller",
+      "polymorph",
+      "privatesanctum",
+      "resilientsphere",
+      "secretchest",
+      "stoneshape",
+      "stoneskin",
+      "walloffire",
+    ],
+    5: [
+      "animateobjects",
+      "arcanehand",
+      "cloudkill",
+      "coneofcold",
+      "conjureelemental",
+      "contactotherplane",
+      "creation",
+      "dominateperson",
+      "dream",
+      "geas",
+      "holdmonster",
+      "legendlore",
+      "mislead",
+      "modifymemory",
+      "passwall",
+      "planarbinding",
+      "scrying",
+      "seeming",
+      "telekinesis",
+      "telepathicbond",
+      "teleportationcircle",
+      "wallofforce",
+      "wallofstone",
+    ],
+    6: [
+      "chainlightning",
+      "circleofdeath",
+      "contingency",
+      "createundead",
+      "disintegrate",
+      "eyebite",
+      "fleshtostone",
+      "freezingsphere",
+      "globeofinvulnerability",
+      "guardsandwards",
+      "instantsummons",
+      "irresistibledance",
+      "magicjar",
+      "masssuggestion",
+      "moveearth",
+      "programmedillusion",
+      "sunbeam",
+      "trueseeing",
+      "wallofice",
+    ],
+    7: [
+      "arcanesword",
+      "delayedblastfireball",
+      "etherealness",
+      "fingerofdeath",
+      "forcecage",
+      "magnificentmansion",
+      "miragearcane",
+      "planeshift",
+      "prismaticspray",
+      "projectimage",
+      "reversegravity",
+      "sequester",
+      "simulacrum",
+      "symbol",
+      "teleport",
+    ],
+    8: [
+      "antimagicfield",
+      "antipathy/sympathy",
+      "clone",
+      "controlweather",
+      "demiplane",
+      "dominatemonster",
+      "feeblemind",
+      "incendiarycloud",
+      "maze",
+      "mindblank",
+      "powerwordstun",
+      "sunburst",
+    ],
+    9: [
+      "astralprojection",
+      "foresight",
+      "gate",
+      "imprisonment",
+      "meteorswarm",
+      "powerwordkill",
+      "prismaticwall",
+      "shapechange",
+      "timestop",
+      "truepolymorph",
+      "weird",
+      "wish",
+    ],
+  },
+  warlock: {
+    0: [
+      "chilltouch",
+      "eldritchblast",
+      "magehand",
+      "minorillusion",
+      "poisonspray",
+      "prestidigitation",
+      "truestrike",
+    ],
+    1: [
+      "charmperson",
+      "comprehendlanguages",
+      "expeditiousretreat",
+      "hellishrebuke",
+      "illusoryscript",
+      "protectionfromevilandgood",
+      "unseenservant",
+    ],
+    2: [
+      "darkness",
+      "enthrall",
+      "holdperson",
+      "invisibility",
+      "mirrorimage",
+      "mistystep",
+      "rayofenfeeblement",
+      "shatter",
+      "spiderclimb",
+      "suggestion",
+    ],
+    3: [
+      "counterspell",
+      "dispelmagic",
+      "fear",
+      "fly",
+      "gaseousform",
+      "hypnoticpattern",
+      "magiccircle",
+      "majorimage",
+      "removecurse",
+      "tongues",
+      "vampirictouch",
+    ],
+    4: ["banishment", "blight", "dimensiondoor", "hallucinatoryterrain"],
+    5: ["contactotherplane", "dream", "holdmonster", "scrying"],
+    6: [
+      "circleofdeath",
+      "conjurefey",
+      "createundead",
+      "eyebite",
+      "fleshtostone",
+      "masssuggestion",
+      "trueseeing",
+    ],
+    7: ["etherealness", "fingerofdeath", "forcecage", "planeshift"],
+    8: ["demiplane", "dominatemonster", "feeblemind", "glibness", "powerwordstun"],
+    9: ["astralprojection", "foresight", "imprisonment", "powerwordkill", "truepolymorph"],
+  },
+};
+
+export function spellOptions(spellNames = Object.keys(spells)) {
+  const result = [];
+  for (const name of spellNames) {
+    const key = name.toLowerCase().replaceAll(" ", "");
+    if (spells[key]) result.push(spells[key]);
+  }
+
+  return result;
+}
+
+export function classSpellOptions(className, level) {
+  const result = [];
+  const spellNames = classSpells[className][level];
+  for (const name of spellNames) {
+    const key = name.toLowerCase().replaceAll(" ", "");
+    if (spells[key]) result.push(spells[key]);
+  }
+
+  return result;
+}


### PR DESCRIPTION
## What's the problem(s) we're trying to solve?
Implement Spells Tab for magic classes
## How does this change solve the problem(s)?
- Adds the `SpellTab` component to show choices for spells
- Add `spellOptions.js` data file to store all spells as well as spells for each class
- Expand `classes.js` to include choices for 1st level spells (will add further levels later)
## What side effects does this change have?
- Reset equipment and spells upon changing classes
## Screenshot(s)

https://user-images.githubusercontent.com/18728526/124530021-b89ef900-ddd9-11eb-9e14-15b665f198c0.mp4

