### PR TITLE
Refactor item grids

### DIFF
--- a/src/components/BackgroundTab.svelte
+++ b/src/components/BackgroundTab.svelte
@@ -2,7 +2,7 @@
   import BACKGROUNDS from "data/backgrounds.js";
   import { capitalize } from "utils/utils.js";
 
-  import ItemCard from "components/ItemCard.svelte";
+  import ItemGrid from "components/ItemGrid.svelte";
 
   export let data;
   export let level = 1;
@@ -27,45 +27,46 @@
       data.background.data[attribute] = [...data.background.data[attribute], item];
     }
   }
+
+  function onSelectBackground(event) {
+    const bgUuid = event.detail.uuid;
+    if (data.background.uuid === bgUuid) {
+      data.background = {
+        uuid: "",
+        data: {
+          personality: [],
+          ideal: [],
+          bond: [],
+          flaw: [],
+        },
+        decisionData: {},
+      };
+    } else {
+      data.background = {
+        uuid: bgUuid,
+        data: {
+          personality: [],
+          ideal: [],
+          bond: [],
+          flaw: [],
+          ...BACKGROUNDS[bgUuid]["data"][level],
+        },
+        decisionData: {},
+      };
+    }
+  }
 </script>
 
 <div class="background-tab">
   <h2>Backgrounds</h2>
-  <div class="backgrounds">
-    {#each Object.keys(BACKGROUNDS) as bgUuid}
-      <ItemCard
-        uuid={bgUuid}
-        disabled={bgUuid !== data.background.uuid && data.background.uuid.length}
-        selected={bgUuid === data.background.uuid}
-        on:selected={() => {
-          if (data.background.uuid === bgUuid) {
-            data.background = {
-              uuid: "",
-              data: {
-                personality: [],
-                ideal: [],
-                bond: [],
-                flaw: [],
-              },
-              decisionData: {},
-            };
-          } else {
-            data.background = {
-              uuid: bgUuid,
-              data: {
-                personality: [],
-                ideal: [],
-                bond: [],
-                flaw: [],
-                ...BACKGROUNDS[bgUuid]["data"][level],
-              },
-              decisionData: {},
-            };
-          }
-        }}
-      />
-    {/each}
-  </div>
+  <ItemGrid
+    uuids={Object.keys(BACKGROUNDS)}
+    selectedUuids={data.background.uuid ? [data.background.uuid] : []}
+    maxSelectable={1}
+    selectable={true}
+    showQuantities={false}
+    on:selected={onSelectBackground}
+  />
 
   {#each characteristics as characteristic}
     {#if BACKGROUNDS?.[data.background.uuid]?.[characteristic]}
@@ -109,12 +110,6 @@
 </div>
 
 <style>
-  .backgrounds {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    grid-gap: 1em;
-  }
-
   .chosen {
     color: green;
   }

--- a/src/components/Choice.svelte
+++ b/src/components/Choice.svelte
@@ -81,6 +81,7 @@
           selected={isOptionSelected(data, option.data)}
           disabled={disabled ||
             (data.length >= choice.choose && !isOptionSelected(data, option.data))}
+          showQuantity={false}
           on:selected={() => {
             onMakeDecision(option.data);
           }}

--- a/src/components/ClassTab.svelte
+++ b/src/components/ClassTab.svelte
@@ -2,47 +2,49 @@
   import CLASSES from "data/classes.js";
   import Choice from "components/Choice.svelte";
   import ItemCard from "components/ItemCard.svelte";
+  import ItemGrid from "components/ItemGrid.svelte";
   import { fade } from "svelte/transition";
   import { cubicInOut } from "svelte/easing";
 
   export let data = {};
   export let level = 1;
+
+  function onSelectClass(event) {
+    const classUuid = event.detail.uuid;
+    if (data.class.uuid === classUuid) {
+      data.class = {
+        uuid: "",
+        data: {},
+        decisionData: {},
+      };
+      data.classEquipment = {
+        data: {},
+        decisionData: {},
+      };
+      data.spells = {
+        data: {},
+        decisionData: {},
+      };
+    } else {
+      data.class = {
+        uuid: classUuid,
+        data: CLASSES[classUuid]["data"][level],
+        decisionData: {},
+      };
+    }
+  }
 </script>
 
 <div class="class-tab">
   <h2>Classes</h2>
-  <div class="classes">
-    {#each Object.keys(CLASSES) as classUuid}
-      <ItemCard
-        uuid={classUuid}
-        disabled={classUuid !== data.class.uuid && data.class.uuid.length}
-        selected={classUuid === data.class.uuid}
-        on:selected={() => {
-          if (data.class.uuid === classUuid) {
-            data.class = {
-              uuid: "",
-              data: {},
-              decisionData: {},
-            };
-            data.classEquipment = {
-              data: {},
-              decisionData: {},
-            };
-            data.spells = {
-              data: {},
-              decisionData: {},
-            };
-          } else {
-            data.class = {
-              uuid: classUuid,
-              data: CLASSES[classUuid]["data"][level],
-              decisionData: {},
-            };
-          }
-        }}
-      />
-    {/each}
-  </div>
+  <ItemGrid
+    uuids={Object.keys(CLASSES)}
+    selectedUuids={data.class.uuid ? [data.class.uuid] : []}
+    maxSelectable={1}
+    selectable={true}
+    showQuantities={false}
+    on:selected={onSelectClass}
+  />
 
   {#if CLASSES[data.class.uuid]?.["choices"]?.[level]}
     <div class="choices" transition:fade|local={{ duration: 200, easing: cubicInOut }}>

--- a/src/components/ItemGrid.svelte
+++ b/src/components/ItemGrid.svelte
@@ -3,17 +3,24 @@
 
   import ItemCard from "components/ItemCard.svelte";
 
-  import { fade } from "svelte/transition";
-  import { cubicInOut } from "svelte/easing";
-
-  export let uuidList = [];
+  export let uuids = [];
+  export let selectedUuids = [];
+  export let maxSelectable = 1;
   export let selectable = true;
   export let showQuantities = true;
 </script>
 
-<div class="item-grid" transition:fade|local={{ duration: 200, easing: cubicInOut }}>
-  {#each Object.entries(countBy(uuidList)) as [uuid, quantity]}
-    <ItemCard {uuid} {selectable} {quantity} showQuantity={showQuantities} />
+<div class="item-grid">
+  {#each Object.entries(countBy(uuids)) as [uuid, quantity]}
+    <ItemCard
+      {uuid}
+      {selectable}
+      {quantity}
+      selected={selectedUuids.includes(uuid)}
+      disabled={!selectedUuids.includes(uuid) && selectedUuids.length >= maxSelectable}
+      showQuantity={showQuantities}
+      on:selected
+    />
   {/each}
 </div>
 

--- a/src/components/RacesTab.svelte
+++ b/src/components/RacesTab.svelte
@@ -1,44 +1,62 @@
 <script>
   import RACES from "data/races.js";
-  import ItemCard from "components/ItemCard.svelte";
+  import ItemGrid from "components/ItemGrid.svelte";
   import Choice from "components/Choice.svelte";
   import { fade } from "svelte/transition";
   import { sineOut } from "svelte/easing";
 
   export let data = {};
+
+  function onSelectRace(event) {
+    const raceUuid = event.detail.uuid;
+    if (data.race.uuid === raceUuid) {
+      data.race = {
+        uuid: "",
+        data: {},
+        decisionData: {},
+      };
+      data.subrace = {
+        uuid: "",
+        data: {},
+        decisionData: {},
+      };
+    } else {
+      data.race = {
+        uuid: raceUuid,
+        data: RACES[raceUuid].data,
+        decisionData: {},
+      };
+    }
+  }
+
+  function onSelectSubrace(event) {
+    const subraceUuid = event.detail.uuid;
+    if (data.subrace.uuid === subraceUuid) {
+      data.subrace = {
+        uuid: "",
+        data: {},
+        decisionData: {},
+      };
+    } else {
+      data.subrace = {
+        uuid: subraceUuid,
+        data: RACES[data.race.uuid].subraces[subraceUuid].data,
+        decisionData: {},
+      };
+    }
+  }
 </script>
 
 <div>
   <h2>Race</h2>
-  <div class="races">
-    {#each Object.keys(RACES) as raceUuid}
-      <ItemCard
-        uuid={raceUuid}
-        disabled={raceUuid !== data.race.uuid && data.race.uuid.length}
-        selected={raceUuid === data.race.uuid}
-        on:selected={() => {
-          if (data.race.uuid === raceUuid) {
-            data.race = {
-              uuid: "",
-              data: {},
-              decisionData: {},
-            };
-            data.subrace = {
-              uuid: "",
-              data: {},
-              decisionData: {},
-            };
-          } else {
-            data.race = {
-              uuid: raceUuid,
-              data: RACES[raceUuid].data,
-              decisionData: {},
-            };
-          }
-        }}
-      />
-    {/each}
-  </div>
+  <ItemGrid
+    uuids={Object.keys(RACES)}
+    selectedUuids={data.race.uuid ? [data.race.uuid] : []}
+    maxSelectable={1}
+    selectable={true}
+    showQuantities={false}
+    on:selected={onSelectRace}
+  />
 
   {#if RACES[data.race.uuid]?.choices}
     <div class="choices" transition:fade|local={{ duration: 200, easing: sineOut }}>
@@ -51,30 +69,14 @@
   {#if RACES[data.race.uuid]?.subraces}
     <div class="subrace" transition:fade|local={{ duration: 200, easing: sineOut }}>
       <h2 class="subrace-header">Subrace</h2>
-      <div class="races">
-        {#each Object.keys(RACES[data.race.uuid].subraces) as subraceUuid}
-          <ItemCard
-            uuid={subraceUuid}
-            disabled={subraceUuid !== data.subrace.uuid && data.subrace.uuid.length}
-            selected={subraceUuid === data.subrace.uuid}
-            on:selected={() => {
-              if (data.subrace.uuid === subraceUuid) {
-                data.subrace = {
-                  uuid: "",
-                  data: {},
-                  decisionData: {},
-                };
-              } else {
-                data.subrace = {
-                  uuid: subraceUuid,
-                  data: RACES[data.race.uuid].subraces[subraceUuid].data,
-                  decisionData: {},
-                };
-              }
-            }}
-          />
-        {/each}
-      </div>
+      <ItemGrid
+        uuids={Object.keys(RACES[data.race.uuid].subraces)}
+        selectedUuids={data.subrace.uuid ? [data.subrace.uuid] : []}
+        maxSelectable={1}
+        selectable={true}
+        showQuantities={false}
+        on:selected={onSelectSubrace}
+      />
     </div>
   {/if}
 

--- a/src/components/ReviewCharacterTab.svelte
+++ b/src/components/ReviewCharacterTab.svelte
@@ -223,38 +223,38 @@
   <div class="section">
     {#if data.subrace?.uuid}
       <ItemGrid
-        uuidList={[data.race.uuid, data.subrace.uuid]}
+        uuids={[data.race.uuid, data.subrace.uuid]}
         selectable={false}
         showQuantities={false}
       />
     {:else if data.race?.uuid}
-      <ItemGrid uuidList={[data.race.uuid]} selectable={false} showQuantities={false} />
+      <ItemGrid uuids={[data.race.uuid]} selectable={false} showQuantities={false} />
     {/if}
   </div>
 
   <h2>Class</h2>
   <div class="section">
     {#if data.class?.uuid}
-      <ItemGrid uuidList={[data.class.uuid]} selectable={false} showQuantities={false} />
+      <ItemGrid uuids={[data.class.uuid]} selectable={false} showQuantities={false} />
     {/if}
   </div>
 
   <h2>Background</h2>
   <div class="section">
     {#if data.background?.uuid}
-      <ItemGrid uuidList={[data.background?.uuid]} selectable={false} showQuantities={false} />
+      <ItemGrid uuids={[data.background?.uuid]} selectable={false} showQuantities={false} />
     {/if}
   </div>
 
   <h2>Equipment</h2>
   <div class="section">
-    <ItemGrid uuidList={mergeData.items} selectable={false} />
+    <ItemGrid uuids={mergeData.items} selectable={false} />
   </div>
 
   <h2>Features</h2>
   <div class="section">
     <ItemGrid
-      uuidList={mergeData?.features?.filter(
+      uuids={mergeData?.features?.filter(
         (uuid) =>
           ![data.race?.uuid, data.subrace?.uuid, data.class?.uuid, data.background?.uuid].includes(
             uuid
@@ -267,7 +267,7 @@
 
   <h2>Spells</h2>
   <div class="section">
-    <ItemGrid uuidList={mergeData.spells} selectable={false} showQuantities={false} />
+    <ItemGrid uuids={mergeData.spells} selectable={false} showQuantities={false} />
   </div>
 
   <footer>


### PR DESCRIPTION
## What's the problem(s) we're trying to solve?
We want to re-use the new `ItemGrid` component in other parts of the app
## How does this change solve the problem(s)?
- Changes the `RacesTab`, `ClassTab`, and `BackgroundTab` components to use `Item Grid`
- The grids in `Choice` will be refactored later
## What side effects does this change have?
N/A
## Screenshot(s)
